### PR TITLE
[SCV-63] STAC Items Missing Bounding Box and STAC License

### DIFF
--- a/docs/OAcore+STAC.yaml
+++ b/docs/OAcore+STAC.yaml
@@ -1,0 +1,1744 @@
+openapi: 3.0.1
+info:
+  title: The SpatioTemporal Asset Catalog API
+  version: 0.9.0
+  license:
+    name: Apache License 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0'
+  description: >-
+    This is an OpenAPI definition of the core SpatioTemporal Asset Catalog API
+    specification. Any service that implements this endpoint to allow search of
+    spatiotemporal assets can be considered a STAC API. The endpoint is also
+    available as an OpenAPI fragment that can be integrated with other OpenAPI
+    definitions, and is designed to slot seamlessly into a OGC API - Features
+    definition.
+  contact:
+    name: STAC Specification
+    url: 'http://stacspec.org'
+tags:
+  - name: Capabilities
+    description: essential characteristics of this API
+  - name: Data
+    description: access to data (features)
+  - name: STAC
+    description: >-
+      Extension to OGC API - Features to support STAC metadata model and search
+      API
+paths:
+  /:
+    get:
+      tags:
+        - Capabilities
+      summary: landing page
+      description: |-
+        Returns the root STAC Catalog or STAC Collection that is the entry point
+        for users to browse with STAC Browser or for search engines to crawl.
+        This can either return a single STAC Collection or more commonly a STAC
+        catalog.
+
+        The landing page provides links to the API definition, the conformance
+        statements, the collections and sub-catalogs.
+      operationId: getLandingPage
+      responses:
+        '200':
+          $ref: '#/components/responses/LandingPage'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /conformance:
+    get:
+      tags:
+        - Capabilities
+      summary: information about specifications that this API conforms to
+      description: |-
+        A list of all conformance classes specified in a standard that the
+        server conforms to.
+      operationId: getConformanceDeclaration
+      responses:
+        '200':
+          $ref: '#/components/responses/ConformanceDeclaration'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /collections:
+    get:
+      tags:
+        - Capabilities
+      summary: the feature collections in the dataset
+      operationId: getCollections
+      responses:
+        '200':
+          $ref: '#/components/responses/Collections'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  '/collections/{collectionId}':
+    get:
+      tags:
+        - Capabilities
+      summary: describe the feature collection with id `collectionId`
+      operationId: describeCollection
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+      responses:
+        '200':
+          $ref: '#/components/responses/Collection'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  '/collections/{collectionId}/items':
+    get:
+      tags:
+        - Data
+      summary: fetch features
+      description: |-
+        Fetch features of the feature collection with id `collectionId`.
+
+        Every feature in a dataset belongs to a collection. A dataset may
+        consist of multiple feature collections. A feature collection is often a
+        collection of features of a similar type, based on a common schema.
+
+        Use content negotiation to request HTML or GeoJSON.
+      operationId: getFeatures
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/bbox'
+        - $ref: '#/components/parameters/datetime'
+      responses:
+        '200':
+          $ref: '#/components/responses/Features'
+        '400':
+          $ref: '#/components/responses/InvalidParameter'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  '/collections/{collectionId}/items/{featureId}':
+    get:
+      tags:
+        - Data
+      summary: fetch a single feature
+      description: |-
+        Fetch the feature with id `featureId` in the feature collection
+        with id `collectionId`.
+
+        Use content negotiation to request HTML or GeoJSON.
+      operationId: getFeature
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+        - $ref: '#/components/parameters/featureId'
+      responses:
+        '200':
+          $ref: '#/components/responses/Feature'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /search:
+    get:
+      summary: Search STAC items with simple filtering.
+      description: |-
+        Retrieve Items matching filters. Intended as a shorthand API for simple
+        queries.
+
+        This method is optional, but you MUST implement `POST /search` if you
+        want to implement this method.
+
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` to the
+        `links` array in `GET /`. As `GET` is the default method, the `method`
+        may not be set explicitly in the link.
+      operationId: getSearchSTAC
+      tags:
+        - STAC
+      parameters:
+        - $ref: '#/components/parameters/bbox'
+        - $ref: '#/components/parameters/datetime'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/ids'
+        - $ref: '#/components/parameters/collectionsArray'
+      responses:
+        '200':
+          description: A feature collection.
+          content:
+            application/geo+json:
+              schema:
+                $ref: '#/components/schemas/itemCollection'
+            text/html:
+              schema:
+                type: string
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+    post:
+      summary: Search STAC items with full-featured filtering.
+      description: |-
+        retrieve items matching filters. Intended as the standard, full-featured
+        query API.
+
+        This method is mandatory to implement if `GET /search` is implemented.
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` and `method`
+        set to `POST` to the `links` array in `GET /`.
+      operationId: postSearchSTAC
+      tags:
+        - STAC
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/searchBody'
+      responses:
+        '200':
+          description: A feature collection.
+          content:
+            application/geo+json:
+              schema:
+                $ref: '#/components/schemas/itemCollection'
+            text/html:
+              schema:
+                type: string
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+components:
+  parameters:
+    bbox:
+      name: bbox
+      in: query
+      description: >-
+        Only features that have a geometry that intersects the bounding box are
+        selected.
+
+        The bounding box is provided as four or six numbers, depending on
+
+        whether the coordinate reference system includes a vertical axis (height
+
+        or depth):
+
+
+        * Lower left corner, coordinate axis 1
+
+        * Lower left corner, coordinate axis 2
+
+        * Minimum value, coordinate axis 3 (optional)
+
+        * Upper right corner, coordinate axis 1
+
+        * Upper right corner, coordinate axis 2
+
+        * Maximum value, coordinate axis 3 (optional)
+
+
+        The coordinate reference system of the values is WGS 84
+
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
+
+        a different coordinate reference system is specified in the parameter
+
+        `bbox-crs`.
+
+
+        For WGS 84 longitude/latitude the values are in most cases the sequence
+
+        of minimum longitude, minimum latitude, maximum longitude and maximum
+
+        latitude. However, in cases where the box spans the antimeridian the
+
+        first value (west-most box edge) is larger than the third value
+
+        (east-most box edge).
+
+
+        If the vertical axis is included, the third and the sixth number are
+
+        the bottom and the top of the 3-dimensional bounding box.
+
+
+        If a feature has multiple spatial geometry properties, it is the
+
+        decision of the server whether only a single spatial geometry property
+
+        is used to determine the extent or all relevant geometries.
+
+
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+
+        `bbox=160.6,-55.95,-170,-25.89`.
+      required: false
+      schema:
+        type: array
+        minItems: 4
+        maxItems: 6
+        items:
+          type: number
+      style: form
+      explode: false
+    collectionId:
+      name: collectionId
+      in: path
+      description: local identifier of a collection
+      required: true
+      schema:
+        type: string
+    datetime:
+      name: datetime
+      in: query
+      description: >-
+        Either a date-time or an interval, open or closed. Date and time
+        expressions
+
+        adhere to RFC 3339. Open intervals are expressed using double-dots.
+
+
+        Examples:
+
+
+        * A date-time: "2018-02-12T23:20:50Z"
+
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+
+
+        Only features that have a temporal property that intersects the value of
+
+        `datetime` are selected.
+
+
+        If a feature has multiple temporal properties, it is the decision of the
+
+        server whether only a single temporal property is used to determine
+
+        the extent or all relevant temporal properties.
+      required: false
+      schema:
+        type: string
+      style: form
+      explode: false
+    featureId:
+      name: featureId
+      in: path
+      description: local identifier of a feature
+      required: true
+      schema:
+        type: string
+    limit:
+      name: limit
+      in: query
+      description: >-
+        The optional limit parameter limits the number of items that are
+        presented in the response document.
+
+
+        Only items are counted that are on the first level of the collection in
+        the response document.
+
+        Nested objects contained within the explicitly requested items shall not
+        be counted.
+
+
+        Minimum = 1. Maximum = 10000. Default = 10.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 10000
+        default: 10
+      style: form
+      explode: false
+    ids:
+      name: ids
+      in: query
+      description: |-
+        Array of Item ids to return. All other filter parameters that further
+        restrict the number of search results are ignored
+      required: false
+      schema:
+        $ref: '#/components/schemas/ids'
+      explode: false
+    collectionsArray:
+      name: collections
+      in: query
+      description: |
+        Array of Collection IDs to include in the search for items.
+        Only Items in one of the provided Collections will be searched
+      required: false
+      schema:
+        $ref: '#/components/schemas/collectionsArray'
+      explode: false
+  schemas:
+    collection:
+      type: object
+      required:
+        - id
+        - links
+        - stac_version
+        - description
+        - license
+        - extent
+      properties:
+        id:
+          description: 'identifier of the collection used, for example, in URIs'
+          type: string
+          example: address
+        title:
+          description: human readable title of the collection
+          type: string
+          example: address
+        description:
+          description: a description of the features in the collection
+          type: string
+          example: An address.
+          $ref: '#/components/schemas/description'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+          example:
+            - href: 'http://data.example.com/buildings'
+              rel: item
+            - href: 'http://example.com/concepts/buildings.html'
+              rel: describedBy
+              type: text/html
+        extent:
+          $ref: '#/components/schemas/extent'
+        itemType:
+          description: >-
+            indicator about the type of the items in the collection (the default
+            value is 'feature').
+          type: string
+          default: feature
+        crs:
+          description: the list of coordinate reference systems supported by the service
+          type: array
+          items:
+            type: string
+          default:
+            - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+          example:
+            - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+            - 'http://www.opengis.net/def/crs/EPSG/0/4326'
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        keywords:
+          type: array
+          description: List of keywords describing the collection.
+          items:
+            type: string
+        license:
+          $ref: '#/components/schemas/license'
+        providers:
+          $ref: '#/components/schemas/providers'
+        summaries:
+          description: |-
+            Summaries are either a unique set of all available values *or*
+            statistics. Statistics by default only specify the range (minimum
+            and maximum values), but can optionally be accompanied by additional
+            statistical values. The range can specify the potential range of
+            values, but it is recommended to be as precise as possible. The set
+            of values must contain at least one element and it is strongly
+            recommended to list all values. It is recommended to list as many
+            properties as reasonable so that consumers get a full overview of
+            the Collection. Properties that are covered by the Collection
+            specification (e.g. `providers` and `license`) may not be repeated
+            in the summaries.
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: array
+                title: Set of values
+                items:
+                  description: A value of any type.
+              - type: object
+                title: Statistics
+                description: |-
+                  By default, only ranges with a minimum and a maximum value can
+                  be specified. Ranges can be specified for ordinal values only,
+                  which means they need to have a rank order. Therefore, ranges
+                  can only be specified for numbers and some special types of
+                  strings. Examples: grades (A to F), dates or times.
+                  Implementors are free to add other derived statistical values
+                  to the object, for example `mean` or `stddev`.
+                required:
+                  - min
+                  - max
+                properties:
+                  min:
+                    anyOf:
+                      - type: string
+                      - type: number
+                  max:
+                    anyOf:
+                      - type: string
+                      - type: number
+      example:
+        stac_version: 0.9.0
+        stac_extensions: []
+        id: Sentinel-2
+        title: 'Sentinel-2 MSI: MultiSpectral Instrument, Level-1C'
+        description: |
+          Sentinel-2 is a wide-swath, high-resolution, multi-spectral
+          imaging mission...
+        license: proprietary
+        keywords:
+          - copernicus
+          - esa
+          - eu
+          - msi
+          - radiance
+          - sentinel
+        providers:
+          - name: ESA
+            roles:
+              - producer
+              - licensor
+            url: 'https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi'
+        extent:
+          spatial:
+            bbox:
+              - - -180
+                - -56
+                - 180
+                - 83
+          temporal:
+            interval:
+              - - '2015-06-23T00:00:00Z'
+                - '2019-07-10T13:44:56Z'
+        summaries:
+          datetime:
+            min: '2015-06-23T00:00:00Z'
+            max: '2019-07-10T13:44:56Z'
+          'sci:citation':
+            - 'Copernicus Sentinel data [Year]'
+          'eo:gsd':
+            - 10
+            - 30
+            - 60
+          platform:
+            - sentinel-2a
+            - sentinel-2b
+          constellation:
+            - sentinel-2
+          instruments:
+            - msi
+          'view:off_nadir':
+            min: 0
+            max: 100
+          'view:sun_elevation':
+            min: 6.78
+            max: 89.9
+          'eo:bands':
+            - - name: B1
+                common_name: coastal
+                center_wavelength: 4.439
+              - name: B2
+                common_name: blue
+                center_wavelength: 4.966
+              - name: B3
+                common_name: green
+                center_wavelength: 5.6
+              - name: B4
+                common_name: red
+                center_wavelength: 6.645
+              - name: B5
+                center_wavelength: 7.039
+              - name: B6
+                center_wavelength: 7.402
+              - name: B7
+                center_wavelength: 7.825
+              - name: B8
+                common_name: nir
+                center_wavelength: 8.351
+              - name: B8A
+                center_wavelength: 8.648
+              - name: B9
+                center_wavelength: 9.45
+              - name: B10
+                center_wavelength: 1.3735
+              - name: B11
+                common_name: swir16
+                center_wavelength: 1.6137
+              - name: B12
+                common_name: swir22
+                center_wavelength: 2.2024
+        links:
+          - rel: self
+            href: 'http://cool-sat.com/collections/Sentinel-2'
+          - rel: root
+            href: 'http://cool-sat.com/collections'
+          - rel: license
+            href: >-
+              https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
+            title: >-
+              Legal notice on the use of Copernicus Sentinel Data and Service
+              Information
+    collections:
+      type: object
+      required:
+        - links
+        - collections
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        collections:
+          type: array
+          items:
+            $ref: '#/components/schemas/collection'
+    confClasses:
+      type: object
+      required:
+        - conformsTo
+      properties:
+        conformsTo:
+          type: array
+          items:
+            type: string
+    exception:
+      type: object
+      description: >-
+        Information about the exception: an error code plus an optional
+        description.
+      required:
+        - code
+      properties:
+        code:
+          type: string
+        description:
+          type: string
+    extent:
+      type: object
+      description: >-
+        The extent of the features in the collection. In the Core only spatial
+        and temporal
+
+        extents are specified. Extensions may add additional members to
+        represent other
+
+        extents, for example, thermal or pressure ranges.
+      properties:
+        spatial:
+          description: The spatial extent of the features in the collection.
+          type: object
+          properties:
+            bbox:
+              description: >-
+                One or more bounding boxes that describe the spatial extent of
+                the dataset.
+
+                In the Core only a single bounding box is supported. Extensions
+                may support
+
+                additional areas. If multiple areas are provided, the union of
+                the bounding
+
+                boxes describes the spatial extent.
+              type: array
+              minItems: 1
+              items:
+                description: >-
+                  Each bounding box is provided as four or six numbers,
+                  depending on
+
+                  whether the coordinate reference system includes a vertical
+                  axis
+
+                  (height or depth):
+
+
+                  * Lower left corner, coordinate axis 1
+
+                  * Lower left corner, coordinate axis 2
+
+                  * Minimum value, coordinate axis 3 (optional)
+
+                  * Upper right corner, coordinate axis 1
+
+                  * Upper right corner, coordinate axis 2
+
+                  * Maximum value, coordinate axis 3 (optional)
+
+
+                  The coordinate reference system of the values is WGS 84
+                  longitude/latitude
+
+                  (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a
+                  different coordinate
+
+                  reference system is specified in `crs`.
+
+
+                  For WGS 84 longitude/latitude the values are in most cases the
+                  sequence of
+
+                  minimum longitude, minimum latitude, maximum longitude and
+                  maximum latitude.
+
+                  However, in cases where the box spans the antimeridian the
+                  first value
+
+                  (west-most box edge) is larger than the third value (east-most
+                  box edge).
+
+
+                  If the vertical axis is included, the third and the sixth
+                  number are
+
+                  the bottom and the top of the 3-dimensional bounding box.
+
+
+                  If a feature has multiple spatial geometry properties, it is
+                  the decision of the
+
+                  server whether only a single spatial geometry property is used
+                  to determine
+
+                  the extent or all relevant geometries.
+                type: array
+                minItems: 4
+                maxItems: 6
+                items:
+                  type: number
+                example:
+                  - -180
+                  - -90
+                  - 180
+                  - 90
+            crs:
+              description: >-
+                Coordinate reference system of the coordinates in the spatial
+                extent
+
+                (property `bbox`). The default reference system is WGS 84
+                longitude/latitude.
+
+                In the Core this is the only supported coordinate reference
+                system.
+
+                Extensions may support additional coordinate reference systems
+                and add
+
+                additional enum values.
+              type: string
+              enum:
+                - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+              default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+          required:
+            - bbox
+        temporal:
+          description: The temporal extent of the features in the collection.
+          type: object
+          properties:
+            interval:
+              description: >-
+                One or more time intervals that describe the temporal extent of
+                the dataset.
+
+                The value `null` is supported and indicates an open time
+                intervall.
+
+                In the Core only a single time interval is supported. Extensions
+                may support
+
+                multiple intervals. If multiple intervals are provided, the
+                union of the
+
+                intervals describes the temporal extent.
+              type: array
+              minItems: 1
+              items:
+                description: >-
+                  Begin and end times of the time interval. The timestamps
+
+                  are in the coordinate reference system specified in `trs`. By
+                  default
+
+                  this is the Gregorian calendar.
+                type: array
+                minItems: 2
+                maxItems: 2
+                items:
+                  type: string
+                  format: date-time
+                  nullable: true
+                example:
+                  - '2011-11-11T12:22:11Z'
+                  - null
+            trs:
+              description: >-
+                Coordinate reference system of the coordinates in the temporal
+                extent
+
+                (property `interval`). The default reference system is the
+                Gregorian calendar.
+
+                In the Core this is the only supported temporal reference
+                system.
+
+                Extensions may support additional temporal reference systems and
+                add
+
+                additional enum values.
+              type: string
+              enum:
+                - 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+              default: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+          required:
+            - interval
+      required:
+        - spatial
+        - temporal
+    featureCollectionGeoJSON:
+      type: object
+      required:
+        - type
+        - features
+      properties:
+        type:
+          type: string
+          enum:
+            - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/item'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        timeStamp:
+          $ref: '#/components/schemas/timeStamp'
+        numberMatched:
+          $ref: '#/components/schemas/numberMatched'
+        numberReturned:
+          $ref: '#/components/schemas/numberReturned'
+    featureGeoJSON:
+      type: object
+      required:
+        - type
+        - geometry
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - Feature
+        geometry:
+          $ref: '#/components/schemas/geometryGeoJSON'
+        properties:
+          type: object
+          nullable: true
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+    geometryGeoJSON:
+      oneOf:
+        - $ref: '#/components/schemas/pointGeoJSON'
+        - $ref: '#/components/schemas/multipointGeoJSON'
+        - $ref: '#/components/schemas/linestringGeoJSON'
+        - $ref: '#/components/schemas/multilinestringGeoJSON'
+        - $ref: '#/components/schemas/polygonGeoJSON'
+        - $ref: '#/components/schemas/multipolygonGeoJSON'
+        - $ref: '#/components/schemas/geometrycollectionGeoJSON'
+    geometrycollectionGeoJSON:
+      type: object
+      required:
+        - type
+        - geometries
+      properties:
+        type:
+          type: string
+          enum:
+            - GeometryCollection
+        geometries:
+          type: array
+          items:
+            $ref: '#/components/schemas/geometryGeoJSON'
+    landingPage:
+      type: object
+      required:
+        - links
+        - stac_version
+        - id
+        - description
+      properties:
+        title:
+          type: string
+          example: Buildings in Bonn
+        description:
+          type: string
+          example: >-
+            Access to data about buildings in the city of Bonn via a Web API
+            that conforms to the OGC API Features specification.
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          type: string
+    linestringGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - LineString
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+    link:
+      type: object
+      required:
+        - href
+        - rel
+      properties:
+        href:
+          type: string
+          example: 'http://www.geoserver.example/stac/naip/child/catalog.json'
+          format: url
+        rel:
+          type: string
+          example: child
+        type:
+          type: string
+          example: application/geo+json
+        hreflang:
+          type: string
+          example: en
+        title:
+          type: string
+          example: NAIP Child Catalog
+        length:
+          type: integer
+        method:
+          type: string
+          enum:
+            - GET
+            - POST
+          default: GET
+          description: Specifies the HTTP method that the link expects
+        headers:
+          type: object
+          description: Object key values pairs they map to headers
+          example:
+            Accept: application/json
+        body:
+          type: object
+          description: >-
+            For POST requests, the link can specify the HTTP body as a JSON
+            object.
+        merge:
+          type: boolean
+          default: false
+          description: |-
+            This is only valid when the server is responding to POST request.
+
+            If merge is true, the client is expected to merge the body value
+            into the current request body before following the link.
+            This avoids passing large post bodies back and forth when following
+            links, particularly for navigating pages through the `POST /search`
+            endpoint.
+
+            NOTE: To support form encoding it is expected that a client be able
+            to merge in the key value pairs specified as JSON
+            `{"next": "token"}` will become `&next=token`.
+      title: Link
+    multilinestringGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiLineString
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
+    multipointGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+    multipolygonGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              type: array
+              minItems: 4
+              items:
+                type: array
+                minItems: 2
+                items:
+                  type: number
+    numberMatched:
+      description: |-
+        The number of features of the feature type that match the selection
+        parameters like `bbox`.
+      type: integer
+      minimum: 0
+      example: 127
+    numberReturned:
+      description: |-
+        The number of features in the feature collection.
+
+        A server may omit this information in a response, if the information
+        about the number of features is not known or difficult to compute.
+
+        If the value is provided, the value shall be identical to the number
+        of items in the "features" array.
+      type: integer
+      minimum: 0
+      example: 10
+    pointGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: number
+    polygonGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 4
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
+    timeStamp:
+      description: >-
+        This property indicates the time and date when the response was
+        generated.
+      type: string
+      format: date-time
+      example: '2017-08-17T08:05:32Z'
+    description:
+      type: string
+      description: |-
+        Detailed multi-line description to fully explain the catalog or
+        collection.
+
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
+        text representation.
+    license:
+      type: string
+      description: |-
+        License(s) of the data as a SPDX
+        [License identifier](https://spdx.org/licenses/). Alternatively, use
+        `proprietary` if the license is not on the SPDX license list or
+        `various` if multiple licenses apply. In these two cases links to the
+        license texts SHOULD be added, see the `license` link relation type.
+
+        Non-SPDX licenses SHOULD add a link to the license text with the
+        `license` relation in the links section. The license text MUST NOT be
+        provided as a value of this field. If there is no public license URL
+        available, it is RECOMMENDED to host the license text and
+        link to it.
+      example: Apache-2.0
+    providers:
+      type: array
+      description: >-
+        A list of providers, which may include all organizations capturing or
+        processing the data or the hosting provider. Providers should be listed
+        in chronological order with the most recent provider being the last
+        element of the list.
+      items:
+        type: object
+        title: Provider
+        required:
+          - name
+        properties:
+          name:
+            description: The name of the organization or the individual.
+            type: string
+          description:
+            description: >-
+              Multi-line description to add further provider information such as
+              processing details for processors and producers, hosting details
+              for hosts or basic contact information.
+
+
+              CommonMark 0.29 syntax MAY be used for rich text representation.
+            type: string
+          roles:
+            description: |-
+              Roles of the provider.
+
+              The provider's role(s) can be one or more of the following
+              elements:
+
+              * licensor: The organization that is licensing the dataset under
+                the license specified in the collection's license field.
+              * producer: The producer of the data is the provider that
+                initially captured and processed the source data, e.g. ESA for
+                Sentinel-2 data.
+              * processor: A processor is any provider who processed data to a
+                derived product.
+              * host: The host is the actual provider offering the data on their
+                storage. There should be no more than one host, specified as last
+                element of the list.
+            type: array
+            items:
+              type: string
+              enum:
+                - producer
+                - licensor
+                - processor
+                - host
+          url:
+            description: >-
+              Homepage on which the provider describes the dataset and publishes
+              contact information.
+            type: string
+            format: url
+    searchBody:
+      description: The search criteria
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/bboxFilter'
+        - $ref: '#/components/schemas/datetimeFilter'
+        - $ref: '#/components/schemas/intersectsFilter'
+        - $ref: '#/components/schemas/collectionsFilter'
+        - $ref: '#/components/schemas/idsFilter'
+        - $ref: '#/components/schemas/limitFilter'
+    limit:
+      type: integer
+      minimum: 1
+      example: 10
+      default: 10
+      maximum: 10000
+      description: The maximum number of results to return (page size). Defaults to 10
+    bbox:
+      description: |-
+        Only features that have a geometry that intersects the bounding box are
+        selected. The bounding box is provided as four or six numbers,
+        depending on whether the coordinate reference system includes a
+        vertical axis (elevation or depth):
+
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2  
+        * Lower left corner, coordinate axis 3 (optional) 
+        * Upper right corner, coordinate axis 1 
+        * Upper right corner, coordinate axis 2 
+        * Upper right corner, coordinate axis 3 (optional)
+
+        The coordinate reference system of the values is WGS84
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
+        a different coordinate reference system is specified in the parameter
+        `bbox-crs`.
+
+        For WGS84 longitude/latitude the values are in most cases the sequence
+        of minimum longitude, minimum latitude, maximum longitude and maximum
+        latitude. However, in cases where the box spans the antimeridian the
+        first value (west-most box edge) is larger than the third value
+        (east-most box edge).
+
+        If a feature has multiple spatial geometry properties, it is the
+        decision of the server whether only a single spatial geometry property
+        is used to determine the extent or all relevant geometries.
+
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+        `bbox=160.6,-55.95,-170,-25.89`.
+      type: array
+      minItems: 4
+      maxItems: 6
+      items:
+        type: number
+      example:
+        - -110
+        - 39.5
+        - -105
+        - 40.5
+    bboxFilter:
+      type: object
+      description: Only return items that intersect the provided bounding box.
+      properties:
+        bbox:
+          $ref: '#/components/schemas/bbox'
+    collectionsArray:
+      type: array
+      description: |-
+        Array of Collection IDs to include in the search for items.
+        Only Items in one of the provided Collections will be searched.
+      items:
+        type: string
+    ids:
+      type: array
+      description: |-
+        Array of Item ids to return. All other filter parameters that further
+        restrict the number of search results are ignored
+      items:
+        type: string
+    datetimeFilter:
+      description: An object representing a date+time based filter.
+      type: object
+      properties:
+        datetime:
+          $ref: '#/components/schemas/datetime'
+    intersectsFilter:
+      type: object
+      description: Only returns items that intersect with the provided polygon.
+      properties:
+        intersects:
+          $ref: 'https://geojson.org/schema/Geometry.json'
+    limitFilter:
+      type: object
+      description: Only returns maximum number of results (page size)
+      properties:
+        limit:
+          $ref: '#/components/schemas/limit'
+    idsFilter:
+      type: object
+      description: Only returns items that match the array of given ids
+      properties:
+        ids:
+          $ref: '#/components/schemas/ids'
+    collectionsFilter:
+      type: object
+      description: Only returns the collections specified
+      properties:
+        collections:
+          $ref: '#/components/schemas/collectionsArray'
+    datetime:
+      type: string
+      description: |-
+        Either a date-time or an interval, open or closed. Date and time
+        expressions adhere to RFC 3339. Open intervals are expressed using
+        double-dots.
+
+        Examples:
+
+        * A date-time: "2018-02-12T23:20:50Z"
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+
+        Only features that have a temporal property that intersects the value of
+        `datetime` are selected.
+
+        If a feature has multiple temporal properties, it is the decision of the
+        server whether only a single temporal property is used to determine
+        the extent or all relevant temporal properties.
+      example: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'
+    stac_version:
+      title: STAC version
+      type: string
+      example: 0.9.0
+    stac_extensions:
+      title: STAC extensions
+      type: array
+      uniqueItems: true
+      items:
+        anyOf:
+          - title: Reference to a JSON Schema
+            type: string
+            format: uri
+          - title: Reference to a core extension
+            type: string
+    itemCollection:
+      description: >-
+        A GeoJSON FeatureCollection augmented with foreign members that contain
+        values relevant to a STAC entity
+      type: object
+      required:
+        - features
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/item'
+        links:
+          $ref: '#/components/schemas/itemCollectionLinks'
+    item:
+      description: >-
+        A GeoJSON Feature augmented with foreign members that contain values
+        relevant to a STAC entity
+      type: object
+      required:
+        - stac_version
+        - id
+        - type
+        - geometry
+        - bbox
+        - links
+        - properties
+        - assets
+      properties:
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          $ref: '#/components/schemas/itemId'
+        bbox:
+          $ref: '#/components/schemas/bbox'
+        geometry:
+          $ref: 'https://geojson.org/schema/Geometry.json'
+        type:
+          $ref: '#/components/schemas/itemType'
+        properties:
+          $ref: '#/components/schemas/itemProperties'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        assets:
+          $ref: '#/components/schemas/itemAssets'
+      example:
+        stac_version: 0.9.0
+        stac_extensions:
+          - eo
+          - view
+          - 'https://example.com/cs-extension/1.0/schema.json'
+        type: Feature
+        id: CS3-20160503_132131_05
+        bbox:
+          - -122.59750209
+          - 37.48803556
+          - -122.2880486
+          - 37.613537207
+        geometry:
+          type: Polygon
+          coordinates:
+            - - - -122.308150179
+                - 37.488035566
+              - - -122.597502109
+                - 37.538869539
+              - - -122.576687533
+                - 37.613537207
+              - - -122.2880486
+                - 37.562818007
+              - - -122.308150179
+                - 37.488035566
+        properties:
+          datetime: '2016-05-03T13:22:30.040Z'
+          title: A CS3 item
+          license: PDDL-1.0
+          providers:
+            - name: CoolSat
+              roles:
+                - producer
+                - licensor
+              url: 'https://cool-sat.com/'
+          'view:sun_azimuth': 168.7
+          'eo:cloud_cover': 0.12
+          'view:off_nadir': 1.4
+          platform: coolsat2
+          instruments:
+            - cool_sensor_v1
+          'eo:bands': []
+          'view:sun_elevation': 33.4
+          'eo:gsd': 0.512
+        collection: CS3
+        links:
+          - rel: self
+            href: 'http://cool-sat.com/collections/CS3/items/20160503_132130_04'
+          - rel: root
+            href: 'http://cool-sat.com/collections'
+          - rel: parent
+            href: 'http://cool-sat.com/collections/CS3'
+          - rel: collection
+            href: 'http://cool-sat.com/collections/CS3'
+        assets:
+          analytic:
+            href: >-
+              http://cool-sat.com/static-catalog/CS3/20160503_132130_04/analytic.tif
+            title: 4-Band Analytic
+          thumbnail:
+            href: >-
+              http://cool-sat.com/static-catalog/CS3/20160503_132130_04/thumbnail.png
+            title: Thumbnail
+    itemId:
+      type: string
+      example: path/to/example.tif
+      description: 'Provider identifier, a unique ID, potentially a link to a file.'
+    itemType:
+      type: string
+      description: The GeoJSON type
+      enum:
+        - Feature
+    itemAssets:
+      type: object
+      additionalProperties:
+        type: object
+        required:
+          - href
+        properties:
+          href:
+            type: string
+            format: url
+            description: Link to the asset object
+            example: >-
+              http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
+          title:
+            type: string
+            description: Displayed title
+            example: Thumbnail
+          description:
+            type: string
+            description: |-
+              Multi-line description to explain the asset.
+
+              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
+              rich text representation.
+            example: Small 256x256px PNG thumbnail for a preview.
+          type:
+            type: string
+            description: Media type of the asset
+            example: image/png
+          roles:
+            type: array
+            items:
+              type: string
+            description: Purposes of the asset
+            example:
+              - thumbnail
+    itemProperties:
+      type: object
+      required:
+        - datetime
+      description: provides the core metatdata fields plus extensions
+      properties:
+        datetime:
+          $ref: '#/components/schemas/datetime'
+      additionalProperties:
+        description: >-
+          Any additional properties added in via Item specification or
+          extensions.
+    itemCollectionLinks:
+      type: array
+      description: >-
+        An array of links. Can be used for pagination, e.g. by providing a link
+        with the `next` relation type.
+      items:
+        $ref: '#/components/schemas/link'
+      example:
+        - rel: next
+          href: >-
+            http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+  responses:
+    LandingPage:
+      description: |-
+        The landing page provides links to the API definition
+        (link relations `service-desc` and `service-doc`),
+        the Conformance declaration (path `/conformance`,
+        link relation `conformance`), and the Feature
+        Collections (path `/collections`, link relation
+        `data`).
+
+        Links to the search endpoints (path `/search`, link relation `search`,
+        method `GET` or `POST`) are **required** to be specified if the API
+        implements `/search` for any of the specified HTTP methods.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/landingPage'
+          example:
+            title: NAIP Imagery
+            description: Catalog of NAIP Imagery.
+            links:
+              - href: 'http://data.example.org/'
+                rel: self
+                type: application/json
+                title: this document
+              - href: 'http://data.example.org/api'
+                rel: service-desc
+                type: application/vnd.oai.openapi+json;version=3.0
+                title: the API definition
+              - href: 'http://data.example.org/api.html'
+                rel: service-doc
+                type: text/html
+                title: the API documentation
+              - href: 'http://data.example.org/conformance'
+                rel: conformance
+                type: application/json
+                title: OGC API conformance classes implemented by this server
+              - href: 'http://data.example.org/collections'
+                rel: data
+                type: application/json
+                title: Information about the feature collections
+              - href: 'http://data.example.org/search'
+                rel: search
+                type: application/json
+                title: Search across feature collections
+            stac_version: 0.9.0
+            id: naip
+        text/html:
+          schema:
+            type: string
+    ConformanceDeclaration:
+      description: |-
+        The URIs of all conformance classes supported by the server.
+
+        To support "generic" clients that want to access multiple
+        OGC API Features implementations - and not "just" a specific
+        API / server, the server declares the conformance
+        classes it implements and conforms to.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/confClasses'
+          example:
+            conformsTo:
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core'
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30'
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html'
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'
+        text/html:
+          schema:
+            type: string
+    Collections:
+      description: >-
+        The feature collections shared by this API.
+
+
+        The dataset is organized as one or more feature collections. This
+        resource
+
+        provides information about and access to the collections.
+
+
+        The response contains the list of collections. For each collection, a
+        link
+
+        to the items in the collection (path
+        `/collections/{collectionId}/items`,
+
+        link relation `items`) as well as key information about the collection.
+
+        This information includes:
+
+
+        * A local identifier for the collection that is unique for the dataset;
+
+        * A list of coordinate reference systems (CRS) in which geometries may
+        be returned by the server. The first CRS is the default coordinate
+        reference system (the default is always WGS 84 with axis order
+        longitude/latitude);
+
+        * An optional title and description for the collection;
+
+        * An optional extent that can be used to provide an indication of the
+        spatial and temporal extent of the collection - typically derived from
+        the data;
+
+        * An optional indicator about the type of the items in the collection
+        (the default value, if the indicator is not provided, is 'feature').
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/collections'
+        text/html:
+          schema:
+            type: string
+    Collection:
+      description: >-
+        Information about the feature collection with id `collectionId`.
+
+
+        The response contains a link to the items in the collection
+
+        (path `/collections/{collectionId}/items`, link relation `items`)
+
+        as well as key information about the collection. This information
+
+        includes:
+
+
+        * A local identifier for the collection that is unique for the dataset;
+
+        * A list of coordinate reference systems (CRS) in which geometries may
+        be returned by the server. The first CRS is the default coordinate
+        reference system (the default is always WGS 84 with axis order
+        longitude/latitude);
+
+        * An optional title and description for the collection;
+
+        * An optional extent that can be used to provide an indication of the
+        spatial and temporal extent of the collection - typically derived from
+        the data;
+
+        * An optional indicator about the type of the items in the collection
+        (the default value, if the indicator is not provided, is 'feature').
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/collection'
+        text/html:
+          schema:
+            type: string
+    Features:
+      description: >-
+        The response is a document consisting of features in the collection.
+
+        The features included in the response are determined by the server
+
+        based on the query parameters of the request. To support access to
+
+        larger collections without overloading the client, the API supports
+
+        paged access with links to the next page, if more features are selected
+
+        that the page size.
+
+
+        The `bbox` and `datetime` parameter can be used to select only a
+
+        subset of the features in the collection (the features that are in the
+
+        bounding box or time interval). The `bbox` parameter matches all
+        features
+
+        in the collection that are not associated with a location, too. The
+
+        `datetime` parameter matches all features in the collection that are
+
+        not associated with a time stamp or interval, too.
+
+
+        The `limit` parameter may be used to control the subset of the
+
+        selected features that should be returned in the response, the page
+        size.
+
+        Each page may include information about the number of selected and
+
+        returned features (`numberMatched` and `numberReturned`) as well as
+
+        links to support paging (link relation `next`).
+      content:
+        application/geo+json:
+          schema:
+            $ref: '#/components/schemas/featureCollectionGeoJSON'
+        text/html:
+          schema:
+            type: string
+    Feature:
+      description: |-
+        fetch the feature with id `featureId` in the feature collection
+        with id `collectionId`
+      content:
+        application/geo+json:
+          schema:
+            $ref: '#/components/schemas/item'
+        text/html:
+          schema:
+            type: string
+    InvalidParameter:
+      description: A query parameter has an invalid value.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+        text/html:
+          schema:
+            type: string
+    NotFound:
+      description: The requested URI was not found.
+    ServerError:
+      description: A server error occurred.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+        text/html:
+          schema:
+            type: string
+servers:
+  - url: 'http://dev.cool-sat.com'
+    description: Development server
+  - url: 'http://www.cool-sat.com'
+    description: Production server

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { wfs, generateAppUrl, logger } = require('../util');
 const cmr = require('../cmr');
+const settings = require('../settings');
 const convert = require('../convert');
 const { generateAppUrlWithoutRelativeRoot, generateSelfUrl, extractParam } = require('../util');
 
@@ -34,7 +35,7 @@ async function getGranules (request, response) {
   const params = Object.assign({ collection_concept_id: conceptId }, cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query));
   const granules = await cmr.findGranules(params);
 
-  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10)
+  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
   const newParams = { ...event.queryStringParameters } || {};
@@ -46,6 +47,7 @@ async function getGranules (request, response) {
 
   const granulesResponse = {
     type: 'FeatureCollection',
+    stac_version: settings.stac.version,
     features: granules.map(gran => convert.cmrGranToFeatureGeoJSON(event, gran)),
     links: [
       {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -69,7 +69,7 @@ function cmrSpatialToStacBbox (cmrGran) {
     bbox = reorderBoxValues(mergedBox);
   }
   if (bbox === null) {
-    throw new Error(`Unknown spatial in ${cmrGran.id}`);
+    bbox = [];
   }
   return bbox;
 }

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -93,15 +93,30 @@ describe('wfs routes', () => {
 
       expect(cmr.findGranules).toHaveBeenCalled();
       expect(convert.cmrGranToFeatureGeoJSON).toHaveBeenCalled();
-      expect(response.json).toHaveBeenCalledWith({ features: [{ response: 'okay' }], links: [{ rel: 'self', href: 'http://example.com' }, { rel: 'next', href: 'http://example.com?page_num=2' }], type: 'FeatureCollection' });
+      expect(response.json).toHaveBeenCalledWith({
+        features: [
+          { response: 'okay' }
+        ],
+        stac_version: '0.8.0',
+        links: [
+          {
+            rel: 'self',
+            href: 'http://example.com'
+          },
+          { rel: 'next',
+            href: 'http://example.com?page_num=2'
+          }
+        ],
+        type: 'FeatureCollection'
+      });
 
       revertFunction(cmr, 'findGranules');
       revertFunction(convert, 'cmrGranToFeatureGeoJSON');
     });
 
-    it('should generate an item collection response with a  prev link', async() => {
+    it('should generate an item collection response with a  prev link', async () => {
       request.query = {};
-      request.apiGateway.event.queryStringParameters = {'page_num': '2'};
+      request.apiGateway.event.queryStringParameters = { page_num: '2' };
 
       mockFunction(cmr, 'findGranules');
       mockFunction(convert, 'cmrGranToFeatureGeoJSON');
@@ -115,6 +130,7 @@ describe('wfs routes', () => {
       expect(convert.cmrGranToFeatureGeoJSON).toHaveBeenCalled();
       expect(response.json).toHaveBeenCalledWith({
         features: [{ response: 'okay' }],
+        stac_version: '0.8.0',
         links: [
           {
             rel: 'self',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -185,7 +185,7 @@ describe('granuleToItem', () => {
 
     it('should return a bounding box containing the WHOLE_WORLD_BBOX', () => {
       cmrCollection = {};
-      expect(() => cmrSpatialToStacBbox(cmrCollection)).toThrow(Error);
+      expect(cmrSpatialToStacBbox(cmrCollection)).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Overview
This branch includes a few changes. It adds `stac_license` to Items and ItemCollections, as well as fixing a bug where `bbox` wasn't always added to Items. The `stac_license` addition was fairly straight-forward, but the bounding box was a little more complex.

## Bounding Box
I figured out the reason that `bbox` wasn't always being added was because previously we were just looking for a field called `boxes` in the CMR granules. The problem was that granules didn't always have this field- they could have a number of spatial geometry types such as boxes, polygon, or points. 
The solution I implemented was a slight variation on what is used for Collections. It searches for a number of geometry types, and converts what's found into a single bounding box. If none of the spatial extents is found, it returns an error. 