### PR TITLE
[SCV-64] STAC Version and License in Collections

### DIFF
--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -34,7 +34,7 @@ async function getGranules (request, response) {
   const params = Object.assign({ collection_concept_id: conceptId }, cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query));
   const granules = await cmr.findGranules(params);
 
-  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10)
+  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
   const newParams = { ...event.queryStringParameters } || {};

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,4 +1,5 @@
 const cmr = require('../cmr');
+const settings = require('../settings');
 const { wfs, generateAppUrl } = require('../util');
 const { WHOLE_WORLD_BBOX, pointStringToPoints, parseOrdinateString, addPointsToBbox, mergeBoxes, reorderBoxValues } = require('./bounding-box');
 
@@ -78,6 +79,7 @@ function cmrCollToWFSColl (event, cmrCollection) {
   if (!cmrCollection) return null;
   return {
     id: cmrCollection.id,
+    stac_version: settings.stac.version,
     title: cmrCollection.dataset_id,
     description: cmrCollection.summary,
     links: createLinks(event, cmrCollection),

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -80,6 +80,7 @@ function cmrCollToWFSColl (event, cmrCollection) {
   return {
     id: cmrCollection.id,
     stac_version: settings.stac.version,
+    license: cmrCollection.license || 'proprietary',
     title: cmrCollection.dataset_id,
     description: cmrCollection.summary,
     links: createLinks(event, cmrCollection),

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -99,9 +99,9 @@ describe('wfs routes', () => {
       revertFunction(convert, 'cmrGranToFeatureGeoJSON');
     });
 
-    it('should generate an item collection response with a  prev link', async() => {
+    it('should generate an item collection response with a  prev link', async () => {
       request.query = {};
-      request.apiGateway.event.queryStringParameters = {'page_num': '2'};
+      request.apiGateway.event.queryStringParameters = { page_num: '2' };
 
       mockFunction(cmr, 'findGranules');
       mockFunction(convert, 'cmrGranToFeatureGeoJSON');

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -176,7 +176,8 @@ describe('collections', () => {
         ],
         id: 'id',
         title: 'datasetId',
-        stac_version: settings.stac.version
+        stac_version: settings.stac.version,
+        license: 'proprietary'
       });
     });
 
@@ -237,7 +238,8 @@ describe('collections', () => {
         ],
         id: 'id',
         title: 'datasetId',
-        stac_version: settings.stac.version
+        stac_version: settings.stac.version,
+        license: 'proprietary'
       });
     });
   });

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -5,6 +5,7 @@ const {
   cmrCollToWFSColl
 } = require('../../lib/convert/collections');
 const { WHOLE_WORLD_BBOX } = require('../../lib/convert');
+const settings = require('../../lib/settings');
 
 describe('collections', () => {
   describe('cmrCollSpatialToExtents', () => {
@@ -174,7 +175,9 @@ describe('collections', () => {
           }
         ],
         id: 'id',
-        title: 'datasetId' });
+        title: 'datasetId',
+        stac_version: settings.stac.version
+      });
     });
 
     it('should return null as the temporal extent end time', () => {
@@ -233,7 +236,9 @@ describe('collections', () => {
           }
         ],
         id: 'id',
-        title: 'datasetId' });
+        title: 'datasetId',
+        stac_version: settings.stac.version
+      });
     });
   });
 });


### PR DESCRIPTION
## Overview
This branch adds the `stac_version` field to Collections, as required in the STAC API spec: https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md
It was a fairly minor adjustment- it just pulls the stac version from `settings.js` and adds it to the response of `cmrCollToWFSColl()` during collections conversion.
The `license` field has been added to collections as well. After talking to the EOSDIS team, we found out that most of the collections in CMR don't have license information. So as a result when adding the value in cmr-stac, it looks for a license, and if one isn't found it sets the value to "proprietary". 