### PR TITLE
[SCV-62] Provider Catalog Validation

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { wfs, generateAppUrl, logger, makeAsyncHandler } = require('../util');
+const { assertValid, schemas } = require('../validator');
 const settings = require('../settings');
 const cmr = require('../cmr');
 
@@ -8,6 +9,7 @@ function convertProvider (event, provider) {
   return {
     id: providerId,
     title: provider['short-name'],
+    description: `Root catalog for ${providerId}`,
     stac_version: settings.stac.version,
     rel: 'provider',
     type: 'application/json',
@@ -30,7 +32,7 @@ async function getProvider (request, response) {
     'provider-id': providerId,
     'short-name': providerId
   });
-  // TODO assert response here
+  await assertValid(schemas.catalog, provider);
   response.status(200).json(provider);
 }
 
@@ -42,7 +44,6 @@ async function getProviders (req, res) {
     description: 'This is the landing page for CMR-STAC. Each provider link below contains a STAC endpoint.',
     links: providerObjects
   };
-  // TODO assert response here
   res.status(200).json(providerCatalog);
 }
 

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -16,6 +16,7 @@ const expectedProviders = [
   {
     id: 'provA',
     title: 'provAShort',
+    description: 'Root catalog for provA',
     stac_version: '1.0.0-beta.1',
     rel: 'provider',
     type: 'application/json',
@@ -43,6 +44,7 @@ const expectedProviders = [
   {
     id: 'provB',
     title: 'provBShort',
+    description: 'Root catalog for provB',
     stac_version: '1.0.0-beta.1',
     rel: 'provider',
     type: 'application/json',
@@ -70,6 +72,7 @@ const expectedProviders = [
   {
     id: 'provC',
     title: 'provCShort',
+    description: 'Root catalog for provC',
     stac_version: '1.0.0-beta.1',
     rel: 'provider',
     type: 'application/json',
@@ -116,10 +119,11 @@ describe('getProviders', () => {
 });
 
 describe('getProvider', () => {
-  it('should return a provider json object', () => {
+  it('should return a provider json object', async () => {
     const expectedResponse = {
       id: 'LARC_ASDC',
       title: 'LARC_ASDC',
+      description: 'Root catalog for LARC_ASDC',
       stac_version: settings.stac.version,
       rel: 'provider',
       links: [
@@ -150,7 +154,7 @@ describe('getProvider', () => {
       }
     });
     const response = createMockResponse();
-    getProvider(request, response);
+    await getProvider(request, response);
     response.expect(expectedResponse);
   });
 });


### PR DESCRIPTION
## Overview
This is a small branch that asserts validation on providers using the `catalog` schema. This only happens on the `getProvider()` function in the `cmr-stac/{provider-id}` endpoint because our root endpoint is not a STAC object or endpoint- it is a list of STAC endpoints.