### PR TITLE
[SCV-92/SCV-53] Empty Collections; /Collections and /Items Next Link

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -17,7 +17,7 @@ function convertProvider (event, provider) {
       wfs.createLink('self', generateAppUrl(event, `/${providerId}`),
         'Root endpoint for this provider'),
       wfs.createLink('root', generateAppUrl(event, '/'),
-          'CMR-STAC Root'),
+        'CMR-STAC Root'),
       wfs.createLink('collections', generateAppUrl(event, `/${providerId}/collections`),
         'Collections for this provider'),
       wfs.createLink('search', generateAppUrl(event, `/${providerId}/search`),
@@ -31,7 +31,7 @@ async function getProvider (request, response) {
     const providerId = request.params.providerId;
     logger.info(`GET /${providerId}`);
     const event = request.apiGateway.event;
-    const providerList = await cmr.getProviders()
+    const providerList = await cmr.getProviders();
     const isProvider = providerList.filter(providerObj => providerObj['provider-id'] === providerId);
     if (isProvider.length === 0) throw new Error(`Provider [${providerId}] not found`);
     const provider = convertProvider(event, {
@@ -43,7 +43,6 @@ async function getProvider (request, response) {
   } catch (e) {
     response.status(400).json(e.message);
   }
-
 }
 
 async function getProviders (request, response) {

--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -16,6 +16,8 @@ function convertProvider (event, provider) {
     links: [
       wfs.createLink('self', generateAppUrl(event, `/${providerId}`),
         'Root endpoint for this provider'),
+      wfs.createLink('root', generateAppUrl(event, '/'),
+          'CMR-STAC Root'),
       wfs.createLink('collections', generateAppUrl(event, `/${providerId}/collections`),
         'Collections for this provider'),
       wfs.createLink('search', generateAppUrl(event, `/${providerId}/search`),
@@ -25,26 +27,34 @@ function convertProvider (event, provider) {
 }
 
 async function getProvider (request, response) {
-  const providerId = request.params.providerId;
-  logger.info(`GET /${providerId}`);
-  const event = request.apiGateway.event;
-  const provider = convertProvider(event, {
-    'provider-id': providerId,
-    'short-name': providerId
-  });
-  await assertValid(schemas.catalog, provider);
-  response.status(200).json(provider);
+  try {
+    const providerId = request.params.providerId;
+    logger.info(`GET /${providerId}`);
+    const event = request.apiGateway.event;
+    const providerList = await cmr.getProviders()
+    const isProvider = providerList.filter(providerObj => providerObj['provider-id'] === providerId);
+    if (isProvider.length === 0) throw new Error(`Provider [${providerId}] not found`);
+    const provider = convertProvider(event, {
+      'provider-id': providerId,
+      'short-name': providerId
+    });
+    await assertValid(schemas.catalog, provider);
+    response.status(200).json(provider);
+  } catch (e) {
+    response.status(400).json(e.message);
+  }
+
 }
 
-async function getProviders (req, res) {
-  const event = req.apiGateway.event;
+async function getProviders (request, response) {
+  const event = request.apiGateway.event;
   const providerObjects = (await cmr.getProviders()).map((provider) => convertProvider(event, provider));
   const providerCatalog = {
     id: 'cmr-stac',
     description: 'This is the landing page for CMR-STAC. Each provider link below contains a STAC endpoint.',
     links: providerObjects
   };
-  res.status(200).json(providerCatalog);
+  response.status(200).json(providerCatalog);
 }
 
 const routes = express.Router();

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -35,24 +35,23 @@ async function getCollections (request, response) {
       links: [
         wfs.createLink('self', generateAppUrl(event, `/${provider}/collections`),
           `All collections provided by ${provider}`),
-        wfs.createLink('root', generateAppUrl(event, '/'), 'CMR-STAC Root'),
-        {
-          rel: 'next',
-          href: nextResultsLink
-        }
+        wfs.createLink('root', generateAppUrl(event, '/'), 'CMR-STAC Root')
       ],
       collections: collections.map(coll => convert.cmrCollToWFSColl(event, coll))
     };
 
     if (currPage > 1 && collectionsResponse.links.length > 1) {
-      collectionsResponse.links.splice(collectionsResponse.links.length - 1, 0, {
+      collectionsResponse.links.push({
         rel: 'prev',
         href: prevResultsLink
       });
     }
 
-    if (collectionsResponse.collections.length < 10) {
-      collectionsResponse.links.splice(collectionsResponse.links.length - 1);
+    if (collectionsResponse.collections.length === 10) {
+      collectionsResponse.links.push({
+        rel: 'next',
+        href: nextResultsLink
+      });
     }
 
     await assertValid(schemas.collections, collectionsResponse);
@@ -75,7 +74,6 @@ async function getCollection (request, response) {
   } catch (e) {
     response.status(400).json(e.message);
   }
-
 }
 
 async function getGranules (request, response) {

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -50,7 +50,7 @@ async function getCollections (request, response) {
   }
 
   if (collectionsResponse.collections.length < 10) {
-    collectionsResponse.links.splice(collectionsResponse.links.length-1);
+    collectionsResponse.links.splice(collectionsResponse.links.length - 1);
   }
 
   await assertValid(schemas.collections, collectionsResponse);

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -6,55 +6,61 @@ const { assertValid, schemas } = require('../validator');
 const settings = require('../settings');
 
 async function getCollections (request, response) {
-  logger.info(`GET ${request.params.providerId}/collections`);
-  const event = request.apiGateway.event;
+  try {
+    logger.info(`GET ${request.params.providerId}/collections`);
+    const event = request.apiGateway.event;
 
-  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
-  const nextPage = currPage + 1;
-  const prevPage = currPage - 1;
-  const newParams = { ...event.queryStringParameters } || {};
-  newParams.page_num = nextPage;
-  const newPrevParams = { ...event.queryStringParameters } || {};
-  newPrevParams.page_num = prevPage;
-  const prevResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newPrevParams);
-  const nextResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newParams);
+    const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
+    const nextPage = currPage + 1;
+    const prevPage = currPage - 1;
+    const newParams = { ...event.queryStringParameters } || {};
+    newParams.page_num = nextPage;
+    const newPrevParams = { ...event.queryStringParameters } || {};
+    newPrevParams.page_num = prevPage;
+    const prevResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newPrevParams);
+    const nextResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newParams);
 
-  const provider = request.params.providerId;
-  const params = Object.assign(
-    { provider_short_name: provider },
-    cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
-  );
-  const collections = await cmr.findCollections(params);
-  const collectionsResponse = {
-    id: provider,
-    stac_version: settings.stac.version,
-    description: `All collections provided by ${provider}`,
-    license: 'not-provided',
-    links: [
-      wfs.createLink('self', generateAppUrl(event, `/${provider}/collections`),
-        `All collections provided by ${provider}`),
-      wfs.createLink('root', generateAppUrl(event, '/'), 'CMR-STAC Root'),
-      {
-        rel: 'next',
-        href: nextResultsLink
-      }
-    ],
-    collections: collections.map(coll => convert.cmrCollToWFSColl(event, coll))
-  };
+    const provider = request.params.providerId;
+    const params = Object.assign(
+        { provider_short_name: provider },
+        cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
+    );
+    const collections = await cmr.findCollections(params);
+    if (!collections.length) throw new Error("Collections not found");
+    const collectionsResponse = {
+      id: provider,
+      stac_version: settings.stac.version,
+      description: `All collections provided by ${provider}`,
+      license: 'not-provided',
+      links: [
+        wfs.createLink('self', generateAppUrl(event, `/${provider}/collections`),
+            `All collections provided by ${provider}`),
+        wfs.createLink('root', generateAppUrl(event, '/'), 'CMR-STAC Root'),
+        {
+          rel: 'next',
+          href: nextResultsLink
+        }
+      ],
+      collections: collections.map(coll => convert.cmrCollToWFSColl(event, coll))
+    };
 
-  if (currPage > 1 && collectionsResponse.links.length > 1) {
-    collectionsResponse.links.splice(collectionsResponse.links.length - 1, 0, {
-      rel: 'prev',
-      href: prevResultsLink
-    });
+    if (currPage > 1 && collectionsResponse.links.length > 1) {
+      collectionsResponse.links.splice(collectionsResponse.links.length - 1, 0, {
+        rel: 'prev',
+        href: prevResultsLink
+      });
+    }
+
+    if (collectionsResponse.collections.length < 10) {
+      collectionsResponse.links.splice(collectionsResponse.links.length - 1);
+    }
+
+    await assertValid(schemas.collections, collectionsResponse);
+    response.status(200).json(collectionsResponse);
+  } catch (e) {
+    response.status(400).json(e.message);
   }
 
-  if (collectionsResponse.collections.length < 10) {
-    collectionsResponse.links.splice(collectionsResponse.links.length - 1);
-  }
-
-  await assertValid(schemas.collections, collectionsResponse);
-  response.status(200).json(collectionsResponse);
 }
 
 async function getCollection (request, response) {
@@ -62,23 +68,30 @@ async function getCollection (request, response) {
   const event = request.apiGateway.event;
   const conceptId = request.params.collectionId;
   const collection = await cmr.getCollection(conceptId);
+  if (!collection) throw new Error;
   const collectionResponse = convert.cmrCollToWFSColl(event, collection);
   await assertValid(schemas.collection, collectionResponse);
   response.status(200).json(collectionResponse);
 }
 
 async function getGranules (request, response) {
-  const conceptId = request.params.collectionId;
-  logger.info(`GET /${request.params.providerId}/collections/${conceptId}/items`);
-  const event = request.apiGateway.event;
-  const params = Object.assign(
-    { collection_concept_id: conceptId },
-    cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
-  );
-  const granules = await cmr.findGranules(params);
-  const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules);
-  await assertValid(schemas.items, granulesResponse);
-  response.status(200).json(granulesResponse);
+  try {
+    const conceptId = request.params.collectionId;
+    logger.info(`GET /${request.params.providerId}/collections/${conceptId}/items`);
+    const event = request.apiGateway.event;
+    const params = Object.assign(
+        { collection_concept_id: conceptId },
+        cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
+    );
+    const granules = await cmr.findGranules(params);
+    if (!granules.length) throw new Error("Items not found");
+    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules);
+    await assertValid(schemas.items, granulesResponse);
+    response.status(200).json(granulesResponse);
+  } catch (e) {
+    response.status(400).json(e.message);
+  }
+
 }
 
 async function getGranule (request, response) {

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -49,6 +49,10 @@ async function getCollections (request, response) {
     });
   }
 
+  if (collectionsResponse.collections.length < 10) {
+    collectionsResponse.links.splice(collectionsResponse.links.length-1);
+  }
+
   await assertValid(schemas.collections, collectionsResponse);
   response.status(200).json(collectionsResponse);
 }

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -86,9 +86,7 @@ function createLinks (event, cmrCollection) {
 }
 
 function cmrCollToWFSColl (event, cmrCollection) {
-  if (!cmrCollection) {
-    return null;
-  }
+  if (!cmrCollection) return [];
   return {
     id: cmrCollection.id,
     short_name: cmrCollection.short_name,

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -86,7 +86,9 @@ function createLinks (event, cmrCollection) {
 }
 
 function cmrCollToWFSColl (event, cmrCollection) {
-  if (!cmrCollection) return null;
+  if (!cmrCollection) {
+    return null;
+  }
   return {
     id: cmrCollection.id,
     short_name: cmrCollection.short_name,

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -260,7 +260,7 @@ function cmrGranulesToFeatureCollection (event, cmrGrans) {
   }
 
   if (granulesResponse.features.length < 10) {
-    granulesResponse.links.splice(granulesResponse.links.length-1);
+    granulesResponse.links.splice(granulesResponse.links.length - 1);
   }
 
   return granulesResponse;

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -242,6 +242,10 @@ function cmrGranulesToFeatureCollection (event, cmrGrans) {
         href: generateSelfUrl(event)
       },
       {
+        rel: 'root',
+        href: generateAppUrl(event, '/')
+      },
+      {
         rel: 'next',
         href: nextResultsLink
       }
@@ -253,6 +257,10 @@ function cmrGranulesToFeatureCollection (event, cmrGrans) {
       rel: 'prev',
       href: prevResultsLink
     });
+  }
+
+  if (granulesResponse.features.length < 10) {
+    granulesResponse.links.splice(granulesResponse.links.length-1);
   }
 
   return granulesResponse;

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -244,23 +244,22 @@ function cmrGranulesToFeatureCollection (event, cmrGrans) {
       {
         rel: 'root',
         href: generateAppUrl(event, '/')
-      },
-      {
-        rel: 'next',
-        href: nextResultsLink
       }
     ]
   };
 
   if (currPage > 1 && granulesResponse.links.length > 1) {
-    granulesResponse.links.splice(1, 0, {
+    granulesResponse.links.push({
       rel: 'prev',
       href: prevResultsLink
     });
   }
 
-  if (granulesResponse.features.length < 10) {
-    granulesResponse.links.splice(granulesResponse.links.length - 1);
+  if (granulesResponse.features.length === 10) {
+    granulesResponse.links.push({
+      rel: 'next',
+      href: nextResultsLink
+    });
   }
 
   return granulesResponse;

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -205,7 +205,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       },
       {
         rel: 'root',
-        href: generateAppUrl(event)
+        href: generateAppUrl(event, '/')
       },
       {
         rel: 'provider',

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -28,6 +28,12 @@ const expectedProviders = [
         type: 'application/json'
       },
       {
+        rel: 'root',
+        href: 'http://example.com/cmr-stac/',
+        title: 'CMR-STAC Root',
+        type: 'application/json'
+      },
+      {
         rel: 'collections',
         href: 'http://example.com/cmr-stac/provA/collections',
         title: 'Collections for this provider',
@@ -56,6 +62,12 @@ const expectedProviders = [
         type: 'application/json'
       },
       {
+        rel: 'root',
+        href: 'http://example.com/cmr-stac/',
+        title: 'CMR-STAC Root',
+        type: 'application/json'
+      },
+      {
         rel: 'collections',
         href: 'http://example.com/cmr-stac/provB/collections',
         title: 'Collections for this provider',
@@ -81,6 +93,12 @@ const expectedProviders = [
         rel: 'self',
         href: 'http://example.com/cmr-stac/provC',
         title: 'Root endpoint for this provider',
+        type: 'application/json'
+      },
+      {
+        rel: 'root',
+        href: 'http://example.com/cmr-stac/',
+        title: 'CMR-STAC Root',
         type: 'application/json'
       },
       {
@@ -131,6 +149,12 @@ describe('getProvider', () => {
           rel: 'self',
           href: 'http://example.com/cmr-stac/LARC_ASDC',
           title: 'Root endpoint for this provider',
+          type: 'application/json'
+        },
+        {
+          rel: 'root',
+          href: 'http://example.com/cmr-stac/',
+          title: 'CMR-STAC Root',
           type: 'application/json'
         },
         {

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -31,8 +31,8 @@ describe('STAC Search', () => {
         href: 'http://example.com'
       },
       {
-        rel: 'next',
-        href: 'http://example.com?page_num=2'
+        rel: 'root',
+        href: 'http://example.com/cmr-stac/'
       }
     ]
   };

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -98,12 +98,12 @@ describe('wfs routes', () => {
             href: 'http://example.com?page_num=2'
           },
           {
-            rel: 'prev',
-            href: 'http://example.com?page_num=1'
-          },
-          {
             rel: 'root',
             href: 'http://example.com/cmr-stac/'
+          },
+          {
+            rel: 'prev',
+            href: 'http://example.com?page_num=1'
           }
         ],
         features: exampleData.stacGrans

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -51,10 +51,6 @@ describe('wfs routes', () => {
             rel: 'root',
             title: 'CMR-STAC Root',
             type: 'application/json'
-          },
-          {
-            rel: 'next',
-            href: 'http://example.com?page_num=2'
           }
         ],
         license: 'not-provided',
@@ -82,8 +78,8 @@ describe('wfs routes', () => {
             href: 'http://example.com'
           },
           {
-            rel: 'next',
-            href: 'http://example.com?page_num=2'
+            rel: 'root',
+            href: 'http://example.com/cmr-stac/'
           }
         ],
         features: exampleData.stacGrans
@@ -106,8 +102,8 @@ describe('wfs routes', () => {
             href: 'http://example.com?page_num=1'
           },
           {
-            rel: 'next',
-            href: 'http://example.com?page_num=3'
+            rel: 'root',
+            href: 'http://example.com/cmr-stac/'
           }
         ],
         features: exampleData.stacGrans

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -324,7 +324,7 @@ describe('granuleToItem', () => {
             },
             {
               rel: 'root',
-              href: 'http://example.com/cmr-stac'
+              href: 'http://example.com/cmr-stac/'
             },
             {
               rel: 'provider',
@@ -338,8 +338,8 @@ describe('granuleToItem', () => {
             href: 'http://example.com/cmr-stac'
           },
           {
-            rel: 'next',
-            href: 'http://example.com/cmr-stac?page_num=2'
+            rel: 'root',
+            href: 'http://example.com/cmr-stac/'
           }
         ]
       });

--- a/search/tests/example-data/lancemodis_stac_gran.json
+++ b/search/tests/example-data/lancemodis_stac_gran.json
@@ -51,7 +51,7 @@
     },
     {
       "rel": "root",
-      "href": "http://example.com/cmr-stac"
+      "href": "http://example.com/cmr-stac/"
     },
     {
       "rel": "provider",

--- a/search/tests/example-data/lpdaac_stac_gran.json
+++ b/search/tests/example-data/lpdaac_stac_gran.json
@@ -51,7 +51,7 @@
     },
     {
       "rel": "root",
-      "href": "http://example.com/cmr-stac"
+      "href": "http://example.com/cmr-stac/"
     },
     {
       "rel": "provider",


### PR DESCRIPTION
## Overview
The majority of this branch is adding validation for individual Providers and removing the `next` link for Collections or ItemCollections that don't have another page of entries.

## Provider Validation
This is validation of individual provider catalogs for when a user enters the url directly (i.e. `https://cmr.earthdata.nasa.gov/{invalid_provider_id}/` ).

Testing can be done by hitting `http://localhost:3000/cmr-stac/larc_asc`

## Pagination and Error Handling
This branch also removes the `next` link if there are no more collections/items in a given Catalog or ItemCollection. If the user manually inputs a URL containing a `page_num=#` param and there are no collections/item on the page you're trying to access, CMR-STAC will respond with a `"No collections found"` or `"No items found"` message.

Testing:
Valid with `next`:  http://localhost:3000/cmr-stac/LARC_ASDC/collections?page_num=70
Valid without `next`: http://localhost:3000/cmr-stac/LARC_ASDC/collections?page_num=71
Invalid: http://localhost:3000/cmr-stac/LARC_ASDC/collections?page_num=72

Valid with `next`:  http://localhost:3000/cmr-stac/LARC_ASDC/collections/C1758588281-LARC_ASDC/items?page_num=6
Valid without `next`: http://localhost:3000/cmr-stac/LARC_ASDC/collections/C1758588281-LARC_ASDC/items?page_num=7
Invalid: http://localhost:3000/cmr-stac/LARC_ASDC/collections/C1758588281-LARC_ASDC/items?page_num=8

## Misc
This branch also has a few odds and ends included such as added `root` links for improved navigation when crawling in the browser.