### PR TITLE
[SCV-101] Invalid provider ID renders a 404 when viewing a collection

### DIFF
--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -50,8 +50,8 @@ async function findCollections (params = {}) {
   return response.data.feed.entry;
 }
 
-async function getCollection (conceptId) {
-  const collections = await findCollections({ concept_id: conceptId });
+async function getCollection (conceptId, providerId) {
+  const collections = await findCollections({ concept_id: conceptId, provider_id: providerId });
   if (collections.length > 0) return collections[0];
   return null;
 }

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -64,6 +64,24 @@ describe('wfs routes', () => {
       await getCollection(request, response);
       response.expect(exampleData.stacColls[0]);
     });
+
+    describe('when no collection is found', () => {
+      beforeEach(() => {
+        mockFunction(cmr, 'getCollection', Promise.resolve(null));
+      });
+
+      afterEach(() => {
+        revertFunction(cmr, 'getCollection');
+      });
+
+      it('should render a 404.', async () => {
+        await getCollection(request, response);
+        expect(response.getData()).toEqual({
+          status: 404,
+          json: 'Collection [1] not found for provider [LPDAAC]'
+        });
+      });
+    });
   });
 
   describe('getGranules', () => {
@@ -86,7 +104,7 @@ describe('wfs routes', () => {
       });
     });
 
-    it('should generate an item collection response with a prev link', async () => {
+    it('should generate an item collection response with a prev link.', async () => {
       request.apiGateway.event.queryStringParameters = { page_num: '2' };
       await getGranules(request, response);
       response.expect({
@@ -112,7 +130,7 @@ describe('wfs routes', () => {
   });
 
   describe('getGranule', () => {
-    it('should generate a item response.', async () => {
+    it('should generate an item response.', async () => {
       await getGranule(request, response);
       response.expect(exampleData.stacGrans[0]);
     });

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -126,29 +126,40 @@ describe('cmr', () => {
     });
   });
 
-  describe('getCollections', () => {
-    beforeEach(() => {
-      axios.get = jest.fn();
-      const cmrResponse = { data: { feed: { entry: { concept_id: 10 } } } };
-      axios.get.mockResolvedValue(cmrResponse);
+  describe('getCollection', () => {
+    describe('when there are results', () => {
+      beforeEach(() => {
+        axios.get = jest.fn();
+        const cmrResponse = { data: { feed: { entry: [{ concept_id: 10 }] } } };
+        axios.get.mockResolvedValue(cmrResponse);
+      });
+
+      it('should return a collection', async () => {
+        const result = await getCollection(10, 'some-provider');
+        expect(axios.get.mock.calls.length).toBe(1);
+        expect(result).toEqual({ concept_id: 10 });
+      });
+
+      it('should include the concept_id and provider_id in the query', async () => {
+        await getCollection(10, 'some-provider');
+        expect(axios.get.mock.calls.length).toBe(1);
+        expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/collections.json');
+        expect(axios.get.mock.calls[0][1]).toEqual({ params: { has_granules: true, concept_id: 10, provider_id: 'some-provider' }, headers: { 'Client-Id': 'cmr-stac-api-proxy' } });
+      });
     });
 
-    it('should return a collection', async () => {
-      const conceptId = 10;
-      const result = await findCollections({ concept_id: conceptId });
+    describe('when there are NO results', () => {
+      beforeEach(() => {
+        axios.get = jest.fn();
+        const cmrResponse = { data: { feed: { entry: [] } } };
+        axios.get.mockResolvedValue(cmrResponse);
+      });
 
-      expect(axios.get.mock.calls.length).toBe(1);
-      expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/collections.json');
-      expect(axios.get.mock.calls[0][1]).toEqual({ params: { has_granules: true, concept_id: 10 }, headers: { 'Client-Id': 'cmr-stac-api-proxy' } });
-      expect(result).toEqual({ concept_id: 10 });
-    });
-
-    it('should return null if there is no conceptId', async () => {
-      const result = await getCollection(10);
-
-      expect(axios.get.mock.calls.length).toBe(1);
-      expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/collections.json');
-      expect(result).toBe(null);
+      it('should return null', async () => {
+        const result = await getCollection(10, 'some-provider');
+        expect(axios.get.mock.calls.length).toBe(1);
+        expect(result).toBeNull();
+      });
     });
   });
 


### PR DESCRIPTION
## Overview

> As a user, I'd like a 404 to be returned for invalid providers

Before, when showing a collection by visiting `/cmr-stac/:providerId/collections/:collectionId`, the `providerId` portion of the path was not validated. Add it as a parameter when querying CMR for the collection to ensure it is valid.

## Testing

Try searching for a collection (`/cmr-stac/LARC_ASDC/collections/C1758588281-LARC_ASDC`) using an invalid collection id or invalid provider id:

* invalid collection id: `/cmr-stac/LARC_ASDC/collections/WRONG-LARC_ASDC`
* invalid provider id: `/cmr-stac/LARC_ASD/collections/C1758588281-LARC_ASDC`

In both cases the app should render a 404 with a helpful error message.
