### PR TITLE
[SCV-90] EO and SAR Extensions

### DIFF
--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -79,15 +79,18 @@ async function getCollection (request, response) {
 async function getGranules (request, response) {
   try {
     const conceptId = request.params.collectionId;
-    logger.info(`GET /${request.params.providerId}/collections/${conceptId}/items`);
+    const providerId = request.params.providerId;
+    logger.info(`GET /${providerId}/collections/${conceptId}/items`);
     const event = request.apiGateway.event;
     const params = Object.assign(
-      { collection_concept_id: conceptId },
+      { collection_concept_id: conceptId,
+        provider: providerId },
       cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
     );
     const granules = await cmr.findGranules(params);
+    const granulesUmm = await cmr.findGranulesUmm(params);
     if (!granules.length) throw new Error('Items not found');
-    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules);
+    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules, granulesUmm);
     await assertValid(schemas.items, granulesResponse);
     response.status(200).json(granulesResponse);
   } catch (e) {
@@ -96,15 +99,19 @@ async function getGranules (request, response) {
 }
 
 async function getGranule (request, response) {
-  logger.info(`GET /${request.params.providerId}/collections/${request.params.collectionId}/items/${request.params.itemId}`);
-  const event = request.apiGateway.event;
-  const collConceptId = request.params.collectionId;
+  const providerId = request.params.providerId;
+  const collectionId = request.params.collectionId;
   const conceptId = request.params.itemId;
-  const granules = await cmr.findGranules({
-    collection_concept_id: collConceptId,
+  logger.info(`GET /${providerId}/collections/${collectionId}/items/${conceptId}`);
+  const event = request.apiGateway.event;
+  const granParams = {
+    collection_concept_id: collectionId,
+    provider: request.params.providerId,
     concept_id: conceptId
-  });
-  const granuleResponse = convert.cmrGranToFeatureGeoJSON(event, granules[0]);
+  };
+  const granules = await cmr.findGranules(granParams);
+  const granulesUmm = await cmr.findGranulesUmm(granParams);
+  const granuleResponse = convert.cmrGranToFeatureGeoJSON(event, granules[0], granulesUmm[0]);
   await assertValid(schemas.item, granuleResponse);
   response.status(200).json(granuleResponse);
 }

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -61,6 +61,11 @@ async function findGranules (params = {}) {
   return response.data.feed.entry;
 }
 
+async function findGranulesUmm (params = {}) {
+  const response = await cmrSearch(makeCmrSearchUrl('/granules.umm_json'), params);
+  return response.data.items;
+}
+
 async function getProviders () {
   const providerUrl = UrlBuilder.create()
     .withProtocol(settings.cmrSearchProtocol)
@@ -114,6 +119,7 @@ module.exports = {
   cmrSearch,
   findCollections,
   findGranules,
+  findGranulesUmm,
   getCollection,
   convertParams,
   fromEntries,

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -108,14 +108,27 @@ const DATA_REL = 'http://esipfed.org/ns/fedsearch/1.1/data#';
 const BROWSE_REL = 'http://esipfed.org/ns/fedsearch/1.1/browse#';
 const DOC_REL = 'http://esipfed.org/ns/fedsearch/1.1/documentation#';
 
-function cmrGranToFeatureGeoJSON (event, cmrGran) {
-  const datetime = cmrGran.time_start;
-  const startDatetime = cmrGran.time_start;
-  const endDatetime = cmrGran.time_end ? cmrGran.time_end : cmrGran.time_start;
+function cmrGranToFeatureGeoJSON (event, cmrGran, cmrGranUmm = {}) {
+  const properties = {};
+
+  properties.datetime = cmrGran.time_start;
+  properties.start_datetime = cmrGran.time_start;
+  properties.end_datetime = cmrGran.time_end ? cmrGran.time_end : cmrGran.time_start;
 
   let dataLink;
   let browseLink;
   let opendapLink;
+
+  const extensions = [];
+  if (!_.isEmpty(cmrGranUmm)) {
+    const attributes = cmrGranUmm.umm.AdditionalAttributes;
+    const eo = attributes.filter(attr => attr.Name === 'CLOUD_COVERAGE');
+    if (eo.length) {
+      extensions.push('eo');
+      const eoValue = eo[0].Values[0];
+      properties['eo:cloud_cover'] = parseInt(eoValue);
+    }
+  }
 
   if (cmrGran.links) {
     dataLink = cmrGran.links.filter(l => l.rel === DATA_REL && !l.inherited);
@@ -186,6 +199,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     id: cmrGran.id,
     short_name: cmrGran.short_name,
     stac_version: settings.stac.version,
+    stac_extensions: extensions,
     collection: cmrGran.collection_concept_id,
     geometry: cmrSpatialToGeoJSONGeometry(cmrGran),
     bbox: cmrSpatialToStacBbox(cmrGran),
@@ -212,16 +226,12 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
         href: generateAppUrl(event, `/${cmrGran.data_center}`)
       }
     ],
-    properties: {
-      datetime: datetime.toString(),
-      start_datetime: startDatetime.toString(),
-      end_datetime: endDatetime.toString()
-    },
+    properties: properties,
     assets
   };
 }
 
-function cmrGranulesToFeatureCollection (event, cmrGrans) {
+function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
   const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
@@ -232,10 +242,20 @@ function cmrGranulesToFeatureCollection (event, cmrGrans) {
   const prevResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newPrevParams);
   const nextResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newParams);
 
+  let features = [];
+  if (cmrGransUmm.length) {
+    for (const gran in cmrGrans) {
+      const stacItem = cmrGranToFeatureGeoJSON(event, cmrGrans[gran], cmrGransUmm[gran]);
+      features.push(stacItem);
+    }
+  } else {
+    features = cmrGrans.map(gran => cmrGranToFeatureGeoJSON(event, gran));
+  }
+
   const granulesResponse = {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
-    features: cmrGrans.map(gran => cmrGranToFeatureGeoJSON(event, gran)),
+    features: features,
     links: [
       {
         rel: 'self',

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -24,12 +24,14 @@ describe('wfs routes', () => {
     mockFunction(cmr, 'findCollections', Promise.resolve(exampleData.cmrColls));
     mockFunction(cmr, 'getCollection', Promise.resolve(exampleData.cmrColls[0]));
     mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranulesUmm', Promise.resolve(exampleData.cmrGransUmm));
   });
 
   afterEach(() => {
     revertFunction(cmr, 'findCollections');
     revertFunction(cmr, 'getCollection');
     revertFunction(cmr, 'findGranules');
+    revertFunction(cmr, 'findGranulesUmm');
   });
 
   describe('getCollections', () => {

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -270,8 +270,8 @@ describe('granuleToItem', () => {
       dataset_id: 'datasetId',
       short_name: 'landsat',
       summary: 'summary',
-      time_start: 0,
-      time_end: 1,
+      time_start: '0',
+      time_end: '1',
       links: [
         {
           href: 'http://example.com/cmr-stac/collections/id',
@@ -293,6 +293,7 @@ describe('granuleToItem', () => {
         features: [{
           id: 1,
           stac_version: settings.stac.version,
+          stac_extensions: [],
           short_name: 'landsat',
           collection: 10,
           geometry: { type: 'Point', coordinates: [139, 77] },

--- a/search/tests/example-data/index.js
+++ b/search/tests/example-data/index.js
@@ -18,6 +18,10 @@ const cmrGrans = fileToContents
   .filter(([name]) => name.endsWith('cmr_gran'))
   .map(([, contents]) => contents);
 
+const cmrGransUmm = fileToContents
+  .filter(([name]) => name.endsWith('cmr_gran_umm'))
+  .map(([, contents]) => contents);
+
 const stacGrans = fileToContents
   .filter(([name]) => name.endsWith('stac_gran'))
   .map(([, contents]) => contents);
@@ -38,6 +42,7 @@ module.exports = {
   cmrColls,
   stacColls,
   cmrGrans,
+  cmrGransUmm,
   stacGrans,
   examplesByName
 };

--- a/search/tests/example-data/lancemodis_stac_gran.json
+++ b/search/tests/example-data/lancemodis_stac_gran.json
@@ -2,6 +2,7 @@
   "type": "Feature",
   "id": "G1848422111-LANCEMODIS",
   "stac_version": "1.0.0-beta.1",
+  "stac_extensions": [],
   "collection": "C1426617060-LANCEMODIS",
   "geometry": {
     "type": "Polygon",

--- a/search/tests/example-data/lpdaac_cmr_gran_umm.json
+++ b/search/tests/example-data/lpdaac_cmr_gran_umm.json
@@ -1,0 +1,103 @@
+{
+  "meta": {
+    "concept-type": "granule",
+    "concept-id": "G1328420897-LPDAAC_ECS",
+    "revision-id": 7,
+    "native-id": "SC:VIP01.004:2242263776",
+    "provider-id": "LPDAAC_ECS",
+    "format": "application/echo10+xml",
+    "revision-date": "2018-07-10T00:03:58Z"
+  },
+  "umm": {
+    "TemporalExtent": {
+      "RangeDateTime": {
+        "BeginningDateTime": "1981-01-01T00:00:00.000Z",
+        "EndingDateTime": "1981-01-01T23:59:59.000Z"
+      }
+    },
+    "GranuleUR": "SC:VIP01.004:2242263776",
+    "AdditionalAttributes": [
+      {
+        "Name": "identifier_product_doi_authority",
+        "Values": [
+          "http://dx.doi.org"
+        ]
+      },
+      {
+        "Name": "identifier_product_doi",
+        "Values": [
+          "10.5067/MEaSUREs/VIP/VIP01.004"
+        ]
+      }
+    ],
+    "SpatialExtent": {
+      "HorizontalSpatialDomain": {
+        "Geometry": {
+          "BoundingRectangles": [
+            {
+              "WestBoundingCoordinate": -180,
+              "EastBoundingCoordinate": 180,
+              "NorthBoundingCoordinate": 90,
+              "SouthBoundingCoordinate": -90
+            }
+          ]
+        }
+      }
+    },
+    "ProviderDates": [
+      {
+        "Date": "2016-09-16T14:36:14.277Z",
+        "Type": "Insert"
+      },
+      {
+        "Date": "2017-08-25T00:07:46.017Z",
+        "Type": "Update"
+      }
+    ],
+    "CollectionReference": {
+      "EntryTitle": "Vegetation Index and Phenology (VIP) Vegetation Indices Daily Global 0.05Deg CMG V004"
+    },
+    "RelatedUrls": [
+      {
+        "URL": "https://e4ftl01.cr.usgs.gov//MODV6_Dal_H/VIP/VIP01.004/1981.01.01/VIP01.A1981001.004.2016175124032.hdf",
+        "Type": "GET DATA",
+        "Description": "This file may be downloaded directly from this link",
+        "MimeType": "application/x-hdfeos"
+      },
+      {
+        "URL": "https://e4ftl01.cr.usgs.gov//WORKING/BRWS/Browse.001/2016.09.16/VIP01.A1981001.004.2016175124032.jpg",
+        "Type": "GET RELATED VISUALIZATION",
+        "Description": "This Browse file may be downloaded directly from this link",
+        "MimeType": "image/jpeg"
+      },
+      {
+        "URL": "https://e4ftl01.cr.usgs.gov//MODV6_Dal_H/VIP/VIP01.004/1981.01.01/VIP01.A1981001.004.2016175124032.hdf.xml",
+        "Type": "VIEW RELATED INFORMATION",
+        "Description": "This Metadata file may be downloaded directly from this link",
+        "MimeType": "text/xml"
+      }
+    ],
+    "DataGranule": {
+      "DayNightFlag": "Unspecified",
+      "Identifiers": [
+        {
+          "Identifier": "VIP01.A1981001.004.2016175124032.hdf",
+          "IdentifierType": "ProducerGranuleId"
+        }
+      ],
+      "ProductionDateTime": "2016-06-23T19:40:44.000Z",
+      "ArchiveAndDistributionInformation": [
+        {
+          "Name": "Not provided",
+          "Size": 37.1923,
+          "SizeUnit": "MB"
+        }
+      ]
+    },
+    "MetadataSpecification": {
+      "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.1",
+      "Name": "UMM-G",
+      "Version": "1.6.1"
+    }
+  }
+}

--- a/search/tests/example-data/lpdaac_stac_gran.json
+++ b/search/tests/example-data/lpdaac_stac_gran.json
@@ -2,6 +2,7 @@
   "type": "Feature",
   "id": "G1328420897-LPDAAC_ECS",
   "stac_version": "1.0.0-beta.1",
+  "stac_extensions": [],
   "collection": "C1328403374-LPDAAC_ECS",
   "geometry": {
     "type": "Polygon",


### PR DESCRIPTION
## Overview
This branch adds the STAC Extensions field to Item and adds `cloud_cover` to properties. 

The currently selected return format of JSON gives us incomplete metadata on fields and collections. Some of the missing fields are EO and SAR information. I figured out that I could still access this information if we used UMM_JSON as the specified response type when querying CMR Search. Unfortunately, this meant unless we wanted to rework the entire system to use UMM_JSON, we have to make two queries to CMR Search for the same granule: one for the general data and then a second to get the EO data. It's not ideal by any means, but it's the only way I could think of to get the EO data without having to completely redo the whole system.

## Caveats/Issues
This ticket had a number of issues. One being that `cloud_cover` was the only EO field I was able to access. The EO spectral bands are listed, but the actual information needed to properly implement the Bands STAC object were behind an authorization wall. The SAR data was also unable to be accessed.

Search also had an issue. Cloud cover is displayed in granules when crawling through collections in the browser, but I wan't able to implement it as a parameter for `search`. This was due to an issue with CMR Search's `cloud_cover` parameter that the CMR team is investigating

## Future work
Once whatever issue is happening with Search's `cloud_cover` parameter is worked out, we'll need to implement it as a usable parameter for CMR-STAC Search. I think this will involve implementing it as part of the `query` STAC API extension