### PR TITLE
[SCV-121] Provider Page Number in Collection Links

### DIFF
--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -16,7 +16,8 @@ const STAC_SEARCH_PARAMS_CONVERSION_MAP = {
 const STAC_QUERY_PARAMS_CONVERSION_MAP = {
   limit: ['limit', (v) => parseInt(v, 10)],
   bbox: ['bbox', parseOrdinateString],
-  datetime: ['temporal', identity]
+  datetime: ['temporal', identity],
+  collectionId: ['collection_concept_id', identity]
 };
 
 const WFS_PARAMS_CONVERSION_MAP = {

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -35,6 +35,7 @@ function stacSearchWithCurrentParams (event, collId, collProvider) {
   const newParams = { ...event.queryStringParameters } || {};
   newParams.collections = collId;
   delete newParams.provider;
+  delete newParams.page_num;
   return generateAppUrl(event, `/${collProvider}/search`, newParams);
 }
 
@@ -43,6 +44,7 @@ function cmrGranuleSearchWithCurrentParams (event, collId) {
   newParams.collection_concept_id = collId;
   delete newParams.collectionId;
   delete newParams.provider;
+  delete newParams.page_num;
   return cmr.makeCmrSearchUrl('granules.json', newParams);
 }
 

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -120,7 +120,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran, cmrGranUmm = {}) {
   let opendapLink;
 
   const extensions = [];
-  if (!_.isEmpty(cmrGranUmm)) {
+  if (!_.isEmpty(cmrGranUmm) && cmrGranUmm.umm.AdditionalAttributes) {
     const attributes = cmrGranUmm.umm.AdditionalAttributes;
     const eo = attributes.filter(attr => attr.Name === 'CLOUD_COVERAGE');
     if (eo.length) {


### PR DESCRIPTION
## Overview
This branch is a quick bug fix to resolve an issue that one of the CMR team members brought up. The issue was that when crawling in the browser, the provider `page_num` querystring parameter was being added to the  collections' `cmr` and `stac` links. These links should not retain any query string parameters other than the collection ID.

The fix is a one-line deletion in both functions that generate these links that removes `page_num` from the parameter object. As far as I know, there should never be an instance where collection links are built using `page_num` as a value. The only search links that should retain `page_num` are for ItemCollections and Items.