### PR TITLE
Add context to search response

### DIFF
--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -7,13 +7,13 @@ const stacExtension = require('../stac/extension');
 const { assertValid, schemas } = require('../validator');
 const { logger, makeAsyncHandler } = require('../util');
 
-async function search (event, params) {
+async function search(event, params) {
   const cmrParams = cmr.convertParams(cmr.STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
-  const granules = await cmr.findGranules(cmrParams);
-  return cmrConverter.cmrGranulesToFeatureCollection(event, granules);
+  const granulesResult = await cmr.findGranules(cmrParams);
+  return cmrConverter.cmrGranulesToFeatureCollection(event, granulesResult);
 }
 
-async function getSearch (request, response) {
+async function getSearch(request, response) {
   const providerId = request.params.providerId;
   logger.info(`GET /${providerId}/search`);
   const event = request.apiGateway.event;
@@ -26,7 +26,7 @@ async function getSearch (request, response) {
   response.status(200).json(formatedResult);
 }
 
-async function postSearch (request, response) {
+async function postSearch(request, response) {
   const providerId = request.params.providerId;
   logger.info(`POST /${providerId}/search`);
   const event = request.apiGateway.event;

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -7,35 +7,36 @@ const stacExtension = require('../stac/extension');
 const { assertValid, schemas } = require('../validator');
 const { logger, makeAsyncHandler } = require('../util');
 
-async function search(event, params) {
+async function search (event, params) {
   const cmrParams = cmr.convertParams(cmr.STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
-  const granulesResult = await cmr.findGranules(cmrParams);
-  return cmrConverter.cmrGranulesToFeatureCollection(event, granulesResult);
+  const searchResult = await cmr.findGranules(cmrParams);
+
+  return { searchResult, featureCollection: cmrConverter.cmrGranulesToFeatureCollection(event, searchResult.granules) };
 }
 
-async function getSearch(request, response) {
+async function getSearch (request, response) {
   const providerId = request.params.providerId;
   logger.info(`GET /${providerId}/search`);
   const event = request.apiGateway.event;
   const query = stacExtension.stripStacExtensionsFromRequestObject(request.query); // The cmr function to convert params can not handle stac extensions
   const params = Object.assign({ provider: providerId }, query);
   const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
-  const result = await search(event, convertedParams);
-  await assertValid(schemas.items, result);
-  const formatedResult = stacExtension.applyStacExtensions(request.query, result); // Apply any stac extensions that are present
-  response.status(200).json(formatedResult);
+  const { searchResult, featureCollection } = await search(event, convertedParams);
+  await assertValid(schemas.items, featureCollection);
+  const formatted = stacExtension.applyStacExtensions(request.query, featureCollection, { context: { searchResult, query } }); // Apply any stac extensions that are present
+  response.status(200).json(formatted);
 }
 
-async function postSearch(request, response) {
+async function postSearch (request, response) {
   const providerId = request.params.providerId;
   logger.info(`POST /${providerId}/search`);
   const event = request.apiGateway.event;
   const body = stacExtension.stripStacExtensionsFromRequestObject(request.body);
   const params = Object.assign({ provider: providerId }, body);
-  const result = await search(event, params);
-  await assertValid(schemas.items, result);
-  const formatedResult = stacExtension.applyStacExtensions(request.body, result); // Apply any stac extensions that are present
-  response.status(200).json(formatedResult);
+  const { searchResult, featureCollection } = await search(event, params);
+  await assertValid(schemas.items, featureCollection);
+  const formatted = stacExtension.applyStacExtensions(request.body, featureCollection, { context: { searchResult, query: params } }); // Apply any stac extensions that are present
+  response.status(200).json(formatted);
 }
 
 const routes = express.Router();

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -23,7 +23,7 @@ async function getSearch (request, response) {
   const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
   const { searchResult, featureCollection } = await search(event, convertedParams);
   await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(request.query, featureCollection, { context: { searchResult, query } }); // Apply any stac extensions that are present
+  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.params.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
   response.status(200).json(formatted);
 }
 
@@ -35,7 +35,7 @@ async function postSearch (request, response) {
   const params = Object.assign({ provider: providerId }, body);
   const { searchResult, featureCollection } = await search(event, params);
   await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(request.body, featureCollection, { context: { searchResult, query: params } }); // Apply any stac extensions that are present
+  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.body.fields, context: { searchResult, query: params } }); // Apply any stac extensions that are present
   response.status(200).json(formatted);
 }
 

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -23,7 +23,7 @@ async function getSearch (request, response) {
   const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
   const { searchResult, featureCollection } = await search(event, convertedParams);
   await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.params.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
+  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.query.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
   response.status(200).json(formatted);
 }
 

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -6,7 +6,7 @@ const convert = require('../convert');
 const { assertValid, schemas } = require('../validator');
 const settings = require('../settings');
 
-class NotFoundError extends Error {}
+class NotFoundError extends Error { }
 
 async function getCollections (request, response) {
   try {
@@ -91,14 +91,16 @@ async function getGranules (request, response) {
     logger.info(`GET /${providerId}/collections/${conceptId}/items`);
     const event = request.apiGateway.event;
     const params = Object.assign(
-      { collection_concept_id: conceptId,
-        provider: providerId },
+      {
+        collection_concept_id: conceptId,
+        provider: providerId
+      },
       cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
     );
     const granulesResult = await cmr.findGranules(params);
     const granulesUmm = await cmr.findGranulesUmm(params);
     if (!granulesResult.granules.length) throw new Error('Items not found');
-    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granulesResult, granulesUmm);
+    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granulesResult.granules, granulesUmm);
     await assertValid(schemas.items, granulesResponse);
     response.status(200).json(granulesResponse);
   } catch (e) {

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -95,10 +95,10 @@ async function getGranules (request, response) {
         provider: providerId },
       cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
     );
-    const granules = await cmr.findGranules(params);
+    const granulesResult = await cmr.findGranules(params);
     const granulesUmm = await cmr.findGranulesUmm(params);
-    if (!granules.length) throw new Error('Items not found');
-    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules, granulesUmm);
+    if (!granulesResult.granules.length) throw new Error('Items not found');
+    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granulesResult, granulesUmm);
     await assertValid(schemas.items, granulesResponse);
     response.status(200).json(granulesResponse);
   } catch (e) {
@@ -117,7 +117,7 @@ async function getGranule (request, response) {
     provider: request.params.providerId,
     concept_id: conceptId
   };
-  const granules = await cmr.findGranules(granParams);
+  const granules = (await cmr.findGranules(granParams)).granules;
   const granulesUmm = await cmr.findGranulesUmm(granParams);
   const granuleResponse = convert.cmrGranToFeatureGeoJSON(event, granules[0], granulesUmm[0]);
   await assertValid(schemas.item, granuleResponse);

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -59,7 +59,9 @@ async function getCollection (conceptId, providerId) {
 
 async function findGranules (params = {}) {
   const response = await cmrSearch(makeCmrSearchUrl('/granules.json'), params);
-  return response.data.feed.entry;
+  const granules = response.data.feed.entry
+  const totalHits = _.get(response, 'headers.cmr-hits', granules.length)
+  return { granules: granules, totalHits: totalHits };
 }
 
 async function findGranulesUmm (params = {}) {

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -59,8 +59,8 @@ async function getCollection (conceptId, providerId) {
 
 async function findGranules (params = {}) {
   const response = await cmrSearch(makeCmrSearchUrl('/granules.json'), params);
-  const granules = response.data.feed.entry
-  const totalHits = _.get(response, 'headers.cmr-hits', granules.length)
+  const granules = response.data.feed.entry;
+  const totalHits = _.get(response, 'headers.cmr-hits', granules.length);
   return { granules: granules, totalHits: totalHits };
 }
 

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -231,8 +231,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran, cmrGranUmm = {}) {
   };
 }
 
-function cmrGranulesToFeatureCollection(event, cmrGranulesResult, cmrGransUmm = []) {
-  const cmrGrans = cmrGranulesResult.granules;
+function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
   const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
@@ -256,11 +255,6 @@ function cmrGranulesToFeatureCollection(event, cmrGranulesResult, cmrGransUmm = 
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
     features: features,
-    context: {
-      returned: features.length,
-      limit: (event.queryStringParameters && event.queryStringParameters.limit) || null,
-      matched: cmrGranulesResult.totalHits,
-    },
     links: [
       {
         rel: 'self',

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -231,7 +231,8 @@ function cmrGranToFeatureGeoJSON (event, cmrGran, cmrGranUmm = {}) {
   };
 }
 
-function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
+function cmrGranulesToFeatureCollection(event, cmrGranulesResult, cmrGransUmm = []) {
+  const cmrGrans = cmrGranulesResult.granules;
   const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
@@ -251,11 +252,15 @@ function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
   } else {
     features = cmrGrans.map(gran => cmrGranToFeatureGeoJSON(event, gran));
   }
-
   const granulesResponse = {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
     features: features,
+    context: {
+      returned: features.length,
+      limit: (event.queryStringParameters && event.queryStringParameters.limit) || null,
+      matched: cmrGranulesResult.totalHits,
+    },
     links: [
       {
         rel: 'self',

--- a/search/lib/stac/extension.js
+++ b/search/lib/stac/extension.js
@@ -1,6 +1,5 @@
 const fieldsExtension = require('./extensions/fields');
 const contextExtension = require('./extensions/context');
-const _ = require('lodash');
 
 const EXTENSION_TYPES = {
   fields: 'fields'
@@ -13,13 +12,11 @@ function stripStacExtensionsFromRequestObject (request) {
   return strippedRequestObject;
 }
 
-function applyStacExtensions (extensions, result, options) {
+function applyStacExtensions (result, options) {
   let resultToReturn = Object.assign({}, result);
-  if (_.hasIn(extensions, EXTENSION_TYPES.fields)) {
-    resultToReturn = fieldsExtension.apply(extensions.fields, resultToReturn);
-  }
 
-  resultToReturn = contextExtension.apply(options.context, resultToReturn);
+  resultToReturn = fieldsExtension.apply(resultToReturn, options.fields);
+  resultToReturn = contextExtension.apply(resultToReturn, options.context);
 
   return resultToReturn;
 }

--- a/search/lib/stac/extension.js
+++ b/search/lib/stac/extension.js
@@ -1,4 +1,5 @@
 const fieldsExtension = require('./extensions/fields');
+const contextExtension = require('./extensions/context');
 const _ = require('lodash');
 
 const EXTENSION_TYPES = {
@@ -12,15 +13,14 @@ function stripStacExtensionsFromRequestObject (request) {
   return strippedRequestObject;
 }
 
-function applyStacExtensions (extensions, result) {
+function applyStacExtensions (extensions, result, options) {
   let resultToReturn = Object.assign({}, result);
   if (_.hasIn(extensions, EXTENSION_TYPES.fields)) {
-    let fields = extensions.fields;
-    if (typeof fields === 'string' || fields instanceof String) {
-      fields = fieldsExtension.convertStacFieldsQueryToObject(fields);
-    }
-    resultToReturn = fieldsExtension.applyStacFieldsExtension(fields, resultToReturn);
+    resultToReturn = fieldsExtension.apply(extensions.fields, resultToReturn);
   }
+
+  resultToReturn = contextExtension.apply(options.context, resultToReturn);
+
   return resultToReturn;
 }
 

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -1,0 +1,12 @@
+function apply ({ query, searchResult }, result) {
+  return {
+    ...result,
+    context: {
+      returned: searchResult.granules.length,
+      limit: query.limit || null,
+      matched: searchResult.totalHits
+    }
+  };
+}
+
+module.exports = { apply };

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -1,4 +1,4 @@
-function apply ({ query, searchResult }, result) {
+function apply (result, { query, searchResult }) {
   return {
     ...result,
     context: {

--- a/search/lib/stac/extensions/fields.js
+++ b/search/lib/stac/extensions/fields.js
@@ -1,14 +1,7 @@
 
 const _ = require('lodash');
 
-function convertStacFieldsQueryToObject (fieldsQuery) {
-  const fieldsArray = fieldsQuery.split(',');
-  const include = fieldsArray.filter(field => field.startsWith('-') === false).map(field => field.replace(/^\+/, ''));
-  const exclude = fieldsArray.filter(field => field.startsWith('-') === true).map(field => field.replace(/^-/, ''));
-  return { include, exclude };
-}
-
-function applyStacFieldsExtension (fields, result) {
+function apply (fields, result) {
   const { _sourceIncludes, _sourceExcludes } = buildFieldsFilter(fields);
 
   result.features = result.features.map(feature => {
@@ -20,15 +13,19 @@ function applyStacFieldsExtension (fields, result) {
   return result;
 }
 
-module.exports = {
-  convertStacFieldsQueryToObject,
-  applyStacFieldsExtension
-};
+module.exports = { apply };
 
 // Private
+function fieldsStringToObject (fieldsQuery) {
+  const fieldsArray = fieldsQuery.split(',');
+  const include = fieldsArray.filter(field => field.startsWith('-') === false).map(field => field.replace(/^\+/, ''));
+  const exclude = fieldsArray.filter(field => field.startsWith('-') === true).map(field => field.replace(/^-/, ''));
+  return { include, exclude };
+}
 
 function buildFieldsFilter (fields) {
-  const { include, exclude } = fields;
+  const fieldsObject = _.isString(fields) ? fieldsStringToObject(fields) : fields;
+  const { include, exclude } = fieldsObject;
   let _sourceIncludes = [
     'id',
     'type',

--- a/search/lib/stac/extensions/fields.js
+++ b/search/lib/stac/extensions/fields.js
@@ -1,7 +1,9 @@
 
 const _ = require('lodash');
 
-function apply (fields, result) {
+function apply (result, fields) {
+  if (_.isUndefined(fields) || _.isNull(fields)) return result;
+
   const { _sourceIncludes, _sourceExcludes } = buildFieldsFilter(fields);
 
   result.features = result.features.map(feature => {

--- a/search/tests/api/extensions/extension.spec.js
+++ b/search/tests/api/extensions/extension.spec.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 const { createRequest } = require('../../util');
 const { stripStacExtensionsFromRequestObject, applyStacExtensions, EXTENSION_TYPES } = require('../../../lib/stac/extension');
 const fieldsExtension = require('../../../lib/stac/extensions/fields');
+const contextExtension = require('../../../lib/stac/extensions/context');
 
 describe('STAC API Extensions', () => {
   let request;
@@ -804,7 +805,8 @@ describe('STAC API Extensions', () => {
   beforeEach(() => {
     request = createRequest({
       body: '{}',
-      params: { providerId: 'LPDAAC',
+      params: {
+        providerId: 'LPDAAC',
         fields: {
           include: [
             'id',
@@ -838,10 +840,12 @@ describe('STAC API Extensions', () => {
 
   describe('applyStacExtensions', () => {
     it('should execute the suite of STAC API Extensions', async () => {
-      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'applyStacFieldsExtension');
+      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'apply');
+      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'apply');
       const extensions = request.params;
-      applyStacExtensions(extensions, result);
+      applyStacExtensions(extensions, result, { context: { searchResult: { granules: [] }, query: {} } });
       expect(applyFieldsExtensionSpy).toHaveBeenCalled();
+      expect(applyContextExtensionSpy).toHaveBeenCalled();
     });
   });
 });

--- a/search/tests/api/extensions/extension.spec.js
+++ b/search/tests/api/extensions/extension.spec.js
@@ -842,8 +842,7 @@ describe('STAC API Extensions', () => {
     it('should execute the suite of STAC API Extensions', async () => {
       const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'apply');
       const applyContextExtensionSpy = jest.spyOn(contextExtension, 'apply');
-      const extensions = request.params;
-      applyStacExtensions(extensions, result, { context: { searchResult: { granules: [] }, query: {} } });
+      applyStacExtensions(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
       expect(applyFieldsExtensionSpy).toHaveBeenCalled();
       expect(applyContextExtensionSpy).toHaveBeenCalled();
     });

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -18,7 +18,7 @@ describe('STAC Search', () => {
       params: { providerId: 'LPDAAC' }
     });
     response = createMockResponse();
-    mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, totalHits: 19 }));
   });
 
   afterEach(() => {
@@ -29,6 +29,11 @@ describe('STAC Search', () => {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
     features: exampleData.stacGrans,
+    context: {
+      limit: null,
+      matched: 19,
+      returned: 2
+    },
     links: [
       {
         rel: 'self',

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -92,11 +92,6 @@ describe('wfs routes', () => {
       response.expect({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
-        context: {
-          limit: null,
-          matched: 2,
-          returned: 2,
-        },
         links: [
           {
             rel: 'self',
@@ -117,11 +112,6 @@ describe('wfs routes', () => {
       response.expect({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
-        context: {
-          limit: null,
-          matched: 2,
-          returned: 2,
-        },
         links: [
           {
             rel: 'self',

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -23,7 +23,7 @@ describe('wfs routes', () => {
     response = createMockResponse();
     mockFunction(cmr, 'findCollections', Promise.resolve(exampleData.cmrColls));
     mockFunction(cmr, 'getCollection', Promise.resolve(exampleData.cmrColls[0]));
-    mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, totalHits: exampleData.cmrGrans.length }));
     mockFunction(cmr, 'findGranulesUmm', Promise.resolve(exampleData.cmrGransUmm));
   });
 
@@ -92,6 +92,11 @@ describe('wfs routes', () => {
       response.expect({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
+        context: {
+          limit: null,
+          matched: 2,
+          returned: 2,
+        },
         links: [
           {
             rel: 'self',
@@ -112,6 +117,11 @@ describe('wfs routes', () => {
       response.expect({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
+        context: {
+          limit: null,
+          matched: 2,
+          returned: 2,
+        },
         links: [
           {
             rel: 'self',

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -100,7 +100,7 @@ describe('cmr', () => {
   describe('findGranules', () => {
     beforeEach(() => {
       axios.get = jest.fn();
-      const cmrResponse = { headers: { "cmr-hits": 199 }, data: { feed: { entry: [{ test: 'value' }] } } };
+      const cmrResponse = { headers: { 'cmr-hits': 199 }, data: { feed: { entry: [{ test: 'value' }] } } };
       axios.get.mockResolvedValue(cmrResponse);
     });
 

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -100,7 +100,7 @@ describe('cmr', () => {
   describe('findGranules', () => {
     beforeEach(() => {
       axios.get = jest.fn();
-      const cmrResponse = { data: { feed: { entry: { test: 'value' } } } };
+      const cmrResponse = { headers: { "cmr-hits": 199 }, data: { feed: { entry: [{ test: 'value' }] } } };
       axios.get.mockResolvedValue(cmrResponse);
     });
 
@@ -108,21 +108,34 @@ describe('cmr', () => {
       jest.restoreAllMocks();
     });
 
-    it('should return a url with /granules.json appended', async () => {
+    it('makes a request to /granules.json', async () => {
+      await findGranules();
+
+      expect(axios.get.mock.calls.length).toBe(1);
+      expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/granules.json');
+    });
+
+    it('makes a request with the supplied params', async () => {
+      await findGranules(params);
+
+      expect(axios.get.mock.calls.length).toBe(1);
+      expect(axios.get.mock.calls[0][1]).toEqual({ params: { param: 'test' }, headers: { 'Client-Id': 'cmr-stac-api-proxy' } });
+    });
+
+    it('returns an object with the returned granules', async () => {
       const result = await findGranules();
 
       expect(axios.get.mock.calls.length).toBe(1);
       expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/granules.json');
-      expect(result).toEqual({ test: 'value' });
+      expect(result).toEqual(expect.objectContaining({ granules: [{ test: 'value' }] }));
     });
 
-    it('should return a url with /granules.json appended and params', async () => {
+    it('returns totalHits from the CMR response header "cmr-hits"', async () => {
       const result = await findGranules(params);
 
       expect(axios.get.mock.calls.length).toBe(1);
       expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/granules.json');
-      expect(axios.get.mock.calls[0][1]).toEqual({ params: { param: 'test' }, headers: { 'Client-Id': 'cmr-stac-api-proxy' } });
-      expect(result).toEqual({ test: 'value' });
+      expect(result).toEqual(expect.objectContaining({ totalHits: 199 }));
     });
   });
 

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -287,15 +287,9 @@ describe('granuleToItem', () => {
     const event = { headers: { Host: 'example.com' }, path: '/cmr-stac', queryStringParameters: [] };
 
     it('should return a CMR Granules search result to a FeatureCollection', () => {
-      const granulesSearchResult = { granules: cmrGran, totalHits: 12345 }
-      expect(cmrGranulesToFeatureCollection(event, granulesSearchResult)).toEqual({
+      expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
-        context: {
-          limit: null,
-          matched: 12345,
-          returned: 1
-        },
         features: [{
           id: 1,
           stac_version: settings.stac.version,

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -286,10 +286,16 @@ describe('granuleToItem', () => {
 
     const event = { headers: { Host: 'example.com' }, path: '/cmr-stac', queryStringParameters: [] };
 
-    it('should return a cmrGranule to a FeatureCollection', () => {
-      expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
+    it('should return a CMR Granules search result to a FeatureCollection', () => {
+      const granulesSearchResult = { granules: cmrGran, totalHits: 12345 }
+      expect(cmrGranulesToFeatureCollection(event, granulesSearchResult)).toEqual({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
+        context: {
+          limit: null,
+          matched: 12345,
+          returned: 1
+        },
         features: [{
           id: 1,
           stac_version: settings.stac.version,

--- a/search/tests/util.js
+++ b/search/tests/util.js
@@ -64,7 +64,8 @@ function createRequest (additionalData = null) {
     },
     body: '{}',
     app: { logger: logger },
-    params: { }
+    query: {},
+    params: {}
   }, additionalData);
 }
 

--- a/search/tests/validator.spec.js
+++ b/search/tests/validator.spec.js
@@ -1,3 +1,4 @@
+
 const _ = require('lodash');
 const validator = require('../lib/validator');
 const exampleData = require('./example-data');

--- a/search/tests/validator.spec.js
+++ b/search/tests/validator.spec.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const validator = require('../lib/validator');
 const exampleData = require('./example-data');


### PR DESCRIPTION
# Problem

We want to try implementing the [`context` extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions). Which provides some information about search results.

# Solution

Using the CMR `num-hits` header and other information, construct a context object containing `returned`,`limit`, and `matched` attributes about the search.