### PR TITLE
[SCV-113] Implement STAC-API sort extension

### DIFF
--- a/docs/postman-collection.stac-cmr-proxy.json
+++ b/docs/postman-collection.stac-cmr-proxy.json
@@ -395,7 +395,36 @@
         "followAuthorizationHeader": false
       },
       "response": []
-    }
+    },
+    {
+			"name": "GET Provider Search with Sort",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{protocol}}://{{host}}/ASF/search?collections=C1213921626-ASF&sortby=-properties.datetime",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"ASF",
+						"search"
+					],
+					"query": [
+						{
+							"key": "collections",
+							"value": "C1213921626-ASF"
+						},
+						{
+							"key": "sortby",
+							"value": "-properties.datetime"
+						}
+					]
+				}
+			},
+			"response": []
+		}
   ]
 }
 

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -15,28 +15,44 @@ async function search (event, params) {
 }
 
 async function getSearch (request, response) {
-  const providerId = request.params.providerId;
-  logger.info(`GET /${providerId}/search`);
-  const event = request.apiGateway.event;
-  const query = stacExtension.stripStacExtensionsFromRequestObject(request.query); // The cmr function to convert params can not handle stac extensions
-  const params = Object.assign({ provider: providerId }, query);
-  const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
-  const { searchResult, featureCollection } = await search(event, convertedParams);
-  await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.query.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
-  response.status(200).json(formatted);
+  try {
+    const providerId = request.params.providerId;
+    logger.info(`GET /${providerId}/search`);
+    const event = request.apiGateway.event;
+    const query = stacExtension.prepare(request.query);
+    const params = Object.assign({ provider: providerId }, query);
+    const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
+    const { searchResult, featureCollection } = await search(event, convertedParams);
+    await assertValid(schemas.items, featureCollection);
+    const formatted = stacExtension.format(featureCollection, { fields: request.query.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
+    response.status(200).json(formatted);
+  } catch (error) {
+    if (error instanceof stacExtension.errors.InvalidSortPropertyError) {
+      response.status(422).json(error.message);
+    } else {
+      throw error;
+    }
+  }
 }
 
 async function postSearch (request, response) {
-  const providerId = request.params.providerId;
-  logger.info(`POST /${providerId}/search`);
-  const event = request.apiGateway.event;
-  const body = stacExtension.stripStacExtensionsFromRequestObject(request.body);
-  const params = Object.assign({ provider: providerId }, body);
-  const { searchResult, featureCollection } = await search(event, params);
-  await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.body.fields, context: { searchResult, query: params } }); // Apply any stac extensions that are present
-  response.status(200).json(formatted);
+  try {
+    const providerId = request.params.providerId;
+    logger.info(`POST /${providerId}/search`);
+    const event = request.apiGateway.event;
+    const body = stacExtension.prepare(request.body);
+    const params = Object.assign({ provider: providerId }, body);
+    const { searchResult, featureCollection } = await search(event, params);
+    await assertValid(schemas.items, featureCollection);
+    const formatted = stacExtension.format(featureCollection, { fields: request.body.fields, context: { searchResult, query: params } }); // Apply any stac extensions that are present
+    response.status(200).json(formatted);
+  } catch (error) {
+    if (error instanceof stacExtension.InvalidSortPropertyError) {
+      response.status(422).json(error.message);
+    } else {
+      throw error;
+    }
+  }
 }
 
 const routes = express.Router();

--- a/search/lib/stac/extension.js
+++ b/search/lib/stac/extension.js
@@ -1,28 +1,36 @@
 const fieldsExtension = require('./extensions/fields');
 const contextExtension = require('./extensions/context');
+const sortExtension = require('./extensions/sort');
 
 const EXTENSION_TYPES = {
   fields: 'fields'
 };
 
-function stripStacExtensionsFromRequestObject (request) {
-  const strippedRequestObject = Object.assign({}, request);
-  // TODO: All STAC API Extension query params must be stripped from GET requests
-  delete strippedRequestObject.fields;
-  return strippedRequestObject;
+// extensions with `prepare` functions modify the request parameters
+function prepare (params) {
+  let preparedParams = Object.assign({}, params);
+
+  preparedParams = fieldsExtension.prepare(preparedParams);
+  preparedParams = sortExtension.prepare(preparedParams);
+
+  return preparedParams;
 }
 
-function applyStacExtensions (result, options) {
+// extensions with `format` functions modify the api response
+function format (result, options) {
   let resultToReturn = Object.assign({}, result);
 
-  resultToReturn = fieldsExtension.apply(resultToReturn, options.fields);
-  resultToReturn = contextExtension.apply(resultToReturn, options.context);
+  resultToReturn = fieldsExtension.format(resultToReturn, options.fields);
+  resultToReturn = contextExtension.format(resultToReturn, options.context);
 
   return resultToReturn;
 }
 
 module.exports = {
   EXTENSION_TYPES,
-  stripStacExtensionsFromRequestObject,
-  applyStacExtensions
+  prepare,
+  format,
+  errors: {
+    InvalidSortPropertyError: sortExtension.InvalidSortPropertyError
+  }
 };

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -1,4 +1,4 @@
-function apply (result, { query, searchResult }) {
+function format (result, { query, searchResult }) {
   return {
     ...result,
     context: {
@@ -9,4 +9,4 @@ function apply (result, { query, searchResult }) {
   };
 }
 
-module.exports = { apply };
+module.exports = { format };

--- a/search/lib/stac/extensions/fields.js
+++ b/search/lib/stac/extensions/fields.js
@@ -1,7 +1,11 @@
 
 const _ = require('lodash');
 
-function apply (result, fields) {
+function prepare (request) {
+  return _.omit(request, ['fields']);
+}
+
+function format (result, fields) {
   if (_.isUndefined(fields) || _.isNull(fields)) return result;
 
   const { _sourceIncludes, _sourceExcludes } = buildFieldsFilter(fields);
@@ -15,7 +19,7 @@ function apply (result, fields) {
   return result;
 }
 
-module.exports = { apply };
+module.exports = { format, prepare };
 
 // Private
 function fieldsStringToObject (fieldsQuery) {

--- a/search/lib/stac/extensions/sort.js
+++ b/search/lib/stac/extensions/sort.js
@@ -1,0 +1,47 @@
+const _ = require('lodash');
+
+// Map STAC sort parameters to their equivalent CMR names
+const CMR_PROP_MAP = {
+  'properties.start_datetime': 'start_date',
+  'properties.end_datetime': 'end_date',
+  'properties.datetime': 'start_date',
+  short_name: 'short_name'
+};
+
+class InvalidSortPropertyError extends Error {
+  constructor (propertyName) {
+    super(`Property [${propertyName}] does not support sorting`);
+  }
+}
+
+const toCmrField = (stacProp) => {
+  const cmrProp = CMR_PROP_MAP[stacProp];
+
+  if (_.isUndefined(cmrProp)) throw new InvalidSortPropertyError(stacProp);
+
+  return cmrProp || stacProp;
+};
+
+const translateStringParam = (sort) => {
+  const direction = ((sort[0]) === '-' ? '-' : '+');
+  const field = sort.replace(/^[+-]/, '');
+  return direction + toCmrField(field);
+};
+
+const translateObjectParam = ({ field, direction }) => (direction === 'desc' ? '-' : '+') + toCmrField(field);
+const prepObject = (paramsObj) => paramsObj.map(translateObjectParam);
+const prepString = (paramString) => paramString.split(',').map(translateStringParam);
+
+function prepare (params) {
+  const strippedParams = _.omit(params, 'sortby');
+
+  if (_.isString(params.sortby)) {
+    return { ...strippedParams, sort_key: prepString(params.sortby) };
+  } else if (_.isArray(params.sortby)) {
+    return { ...strippedParams, sort_key: prepObject(params.sortby) };
+  }
+
+  return strippedParams;
+}
+
+module.exports = { prepare, InvalidSortPropertyError };

--- a/search/tests/api/extensions/extension.spec.js
+++ b/search/tests/api/extensions/extension.spec.js
@@ -5,7 +5,7 @@
 const _ = require('lodash');
 
 const { createRequest } = require('../../util');
-const { stripStacExtensionsFromRequestObject, applyStacExtensions, EXTENSION_TYPES } = require('../../../lib/stac/extension');
+const { prepare, format, EXTENSION_TYPES } = require('../../../lib/stac/extension');
 const fieldsExtension = require('../../../lib/stac/extensions/fields');
 const contextExtension = require('../../../lib/stac/extensions/context');
 
@@ -807,6 +807,7 @@ describe('STAC API Extensions', () => {
       body: '{}',
       params: {
         providerId: 'LPDAAC',
+        sortby: '+id',
         fields: {
           include: [
             'id',
@@ -824,25 +825,20 @@ describe('STAC API Extensions', () => {
     });
   });
 
-  describe('stripStacExtensionsFromRequestObject', () => {
+  describe('prepare', () => {
     it('should remove all STAC API extensions from the HTTP request', async () => {
-      const strippedRequestObject = stripStacExtensionsFromRequestObject(request);
+      const strippedRequestObject = prepare(request);
 
-      // TODO: We need to add support for all STAC API Extensions (e.g. sort, query, etc)
-      let containsSTACExtensions = false;
-      if (_.hasIn(strippedRequestObject, EXTENSION_TYPES.fields)) {
-        containsSTACExtensions = true;
-      }
-
-      expect(containsSTACExtensions).toBe(false);
+      expect(_.hasIn(strippedRequestObject, EXTENSION_TYPES.fields)).toBe(false);
+      expect(_.hasIn(strippedRequestObject, 'sortby')).toBe(false);
     });
   });
 
-  describe('applyStacExtensions', () => {
+  describe('format', () => {
     it('should execute the suite of STAC API Extensions', async () => {
-      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'apply');
-      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'apply');
-      applyStacExtensions(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
+      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'format');
+      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'format');
+      format(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
       expect(applyFieldsExtensionSpy).toHaveBeenCalled();
       expect(applyContextExtensionSpy).toHaveBeenCalled();
     });

--- a/search/tests/api/extensions/sort.spec.js
+++ b/search/tests/api/extensions/sort.spec.js
@@ -1,0 +1,78 @@
+const { prepare, InvalidSortPropertyError } = require('../../../lib/stac/extensions/sort');
+
+/**
+ * @jest-environment node
+ */
+describe('STAC API sort extension', () => {
+  describe('prepare()', () => {
+    it('strips the sortby param', () => {
+      expect(
+        prepare({ sortby: 'short_name' }).sortby
+      ).toBeUndefined();
+      expect(
+        prepare({ sortby: {} }).sortby
+      ).toBeUndefined();
+    });
+    it('is a noop if no argument is given', () => {
+      expect(
+        prepare({ anotherParam: '123' })
+      ).toEqual({ anotherParam: '123' });
+    });
+
+    describe('given a string', () => {
+      it('returns a sort argument for CMR', async () => {
+        expect(
+          prepare({ sortby: 'short_name' })
+        ).toEqual(
+          { sort_key: ['+short_name'] }
+        );
+      });
+
+      it('manages sorting by multiple properties', async () => {
+        expect(
+          prepare({ sortby: 'short_name,-properties.start_datetime,+properties.end_datetime' })
+        ).toEqual(
+          { sort_key: ['+short_name', '-start_date', '+end_date'] }
+        );
+      });
+
+      it('raises an error given a bad property', async () => {
+        expect(
+          () => prepare({ sortby: 'wack-property,-properties.start_datetime' })
+        ).toThrow(InvalidSortPropertyError);
+      });
+    });
+
+    describe('given an object', () => {
+      it('returns a sort argument for CMR', async () => {
+        expect(
+          prepare({ sortby: [{ field: 'short_name', direction: 'asc' }] })
+        ).toEqual(
+          { sort_key: ['+short_name'] }
+        );
+      });
+
+      it('raises an error given a bad property', async () => {
+        expect(
+          () => prepare({ sortby: [{ field: 'short_name', direction: 'desc' }, {
+            field: 'not-a-real-field',
+            direction: 'asc'
+          }] })
+        ).toThrow(InvalidSortPropertyError);
+      });
+
+      it('manages sorting by multiple properties', async () => {
+        expect(
+          prepare({
+            sortby: [{ field: 'short_name', direction: 'desc' }, {
+              field: 'properties.start_datetime',
+              direction: 'asc'
+            }]
+          })
+        ).toEqual(
+          { sort_key: ['-short_name', '+start_date'] }
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Problem

We want to be able to sort results using the sort extension: 

https://github.com/radiantearth/stac-api-spec/tree/master/extensions

# Solution

Implement a limited scope sort extension. Which allows users to sort by short_name, and the properties start_datetime, end_datetime, and datetime. Which seemed to be the only fields which overlapped with CMR's sorting abilities.

# Implementation

Extend the request preparation pattern for extensions, from just deleting properties, to allow for adding new properties as well. Use the CMR [sort_keys[] functionality](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#sorting-granule-results) and map the incoming `sortby` STAC params to the corresponding CMR sort_keys. Raise an error (422) if a property is not specifically supported.