### PR TITLE
[SCV-112] Context extension fixups

### DIFF
--- a/search/lib/stac/extension.js
+++ b/search/lib/stac/extension.js
@@ -23,7 +23,7 @@ function format (result, options) {
   let resultToReturn = Object.assign({}, result);
 
   resultToReturn = fieldsExtension.format(resultToReturn, options.fields);
-  resultToReturn = contextExtension.format(resultToReturn, options.context);
+  resultToReturn = contextExtension.apply(resultToReturn, options.context);
 
   return resultToReturn;
 }

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -1,11 +1,14 @@
+const _ = require('lodash');
+const CMR_DEFAULT_LIMIT = 1000000;
+
 function apply (result, { query, searchResult }) {
+  const returned = searchResult.granules.length;
+  const matched = _.toInteger(searchResult.totalHits);
+  const limit = query.limit ? _.toInteger(query.limit) : CMR_DEFAULT_LIMIT;
+
   return {
     ...result,
-    context: {
-      returned: searchResult.granules.length,
-      limit: query.limit || null,
-      matched: searchResult.totalHits
-    }
+    context: { returned, limit, matched }
   };
 }
 

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -11,4 +11,4 @@ function apply (result, { query, searchResult }) {
   };
 }
 
-module.exports = { format };
+module.exports = { apply };

--- a/search/tests/api/extensions/extension.spec.js
+++ b/search/tests/api/extensions/extension.spec.js
@@ -837,7 +837,7 @@ describe('STAC API Extensions', () => {
   describe('format', () => {
     it('should execute the suite of STAC API Extensions', async () => {
       const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'format');
-      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'format');
+      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'apply');
       format(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
       expect(applyFieldsExtensionSpy).toHaveBeenCalled();
       expect(applyContextExtensionSpy).toHaveBeenCalled();

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -30,7 +30,7 @@ describe('STAC Search', () => {
     stac_version: settings.stac.version,
     features: exampleData.stacGrans,
     context: {
-      limit: null,
+      limit: 1000000,
       matched: 19,
       returned: 2
     },


### PR DESCRIPTION
# Problem

I ran some QA, and noticed that:

* the `context.matched` attribute is a string, but it should be an integer.
* the `context.limit`, if not supplied, should be the CMR limit (as suggested by @fgabelmannjr) of 1,000,000 granules

# Solution

Fix those two things!
